### PR TITLE
DeviceDataReceivedEventArgs: Using interface instead of ushort[],stri…ng[] for data transfer between WTXJet/Modbus and GUI.DeviceDataReceivedEventArgs: Using interface instead of ushort[],stri…

### DIFF
--- a/Examples/GUIsimple/GUIsimple.cs
+++ b/Examples/GUIsimple/GUIsimple.cs
@@ -173,39 +173,40 @@ namespace WTXGUIsimple
 
         //Callback for automatically receiving event based data from the device
         private void update(object sender, DeviceDataReceivedEventArgs e)
-        {           
+        {
+
             txtInfo.Invoke(new Action(() =>
             {
-                int taraValue = _wtxDevice.NetValue - _wtxDevice.GrossValue;
+                int taraValue = e.ProcessData.NetValue - e.ProcessData.GrossValue;
 
-                txtInfo.Text = "Net:" + _wtxDevice.CurrentWeight(_wtxDevice.NetValue, _wtxDevice.Decimals) + _wtxDevice.UnitStringComment() + Environment.NewLine
-                + "Gross:" + _wtxDevice.CurrentWeight(_wtxDevice.GrossValue, _wtxDevice.Decimals) + _wtxDevice.UnitStringComment() + Environment.NewLine
-                + "Tara:" + _wtxDevice.CurrentWeight(taraValue, _wtxDevice.Decimals) + _wtxDevice.UnitStringComment();
+                txtInfo.Text = "Net:" + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) + _wtxDevice.UnitStringComment() + Environment.NewLine
+                + "Gross:" + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + _wtxDevice.UnitStringComment() + Environment.NewLine
+                + "Tara:" + _wtxDevice.CurrentWeight(taraValue, e.ProcessData.Decimals) + _wtxDevice.UnitStringComment();
                 txtInfo.TextAlign = HorizontalAlignment.Right;
             }));
 
-
             txtInfo.Invoke(new Action(() =>
             {
-                if (_wtxDevice.LimitStatus == 1)
+                if (e.ProcessData.LimitStatus == 1)
                 {
                     txtInfo.Text = "Lower than minimum" + Environment.NewLine;
                     txtInfo.TextAlign = HorizontalAlignment.Right;
 
                 }
-                if (_wtxDevice.LimitStatus == 2)
+                if (e.ProcessData.LimitStatus == 2)
                 {
                     txtInfo.Text = "Higher than maximum capacity" + Environment.NewLine;
                     txtInfo.TextAlign = HorizontalAlignment.Right;
 
                 }
-                if (_wtxDevice.LimitStatus == 3)
+                if (e.ProcessData.LimitStatus == 3)
                 {
                     txtInfo.Text = "Higher than safe load limit" + Environment.NewLine;
                     txtInfo.TextAlign = HorizontalAlignment.Right;
 
                 }
             }));
+            
         }
         
         #endregion

--- a/HBM.Weighing.API/BaseWTDevice.cs
+++ b/HBM.Weighing.API/BaseWTDevice.cs
@@ -31,7 +31,7 @@ using System;
 
 namespace HBM.Weighing.API
 {
-    public abstract class BaseWtDevice 
+    public abstract class BaseWtDevice:IDeviceData 
     {
 
         protected INetConnection connection;

--- a/HBM.Weighing.API/DeviceDataReceivedEventArgs.cs
+++ b/HBM.Weighing.API/DeviceDataReceivedEventArgs.cs
@@ -27,43 +27,73 @@
 // SOFTWARE.
 //
 // </copyright>
+using HBM.Weighing.API.WTX;
 using System;
 
 namespace HBM.Weighing.API
 {
     public class DeviceDataReceivedEventArgs : EventArgs 
     {
-        private ushort[] _ushortArgs;
-        private string[] _strArgs;
+        private IDeviceData _processData; 
 
-        public DeviceDataReceivedEventArgs(ushort[] _ushortArrayParam, string[] _strArrayParam)
+        public DeviceDataReceivedEventArgs(IDeviceData _Idata)
         {
-            _ushortArgs = _ushortArrayParam;
-            _strArgs = _strArrayParam;
+            _processData = _Idata;
         }
        
-        public ushort[] ushortArgs
+        public IDeviceData ProcessData
         {
             get
             {
-                return _ushortArgs;
+                return _processData;
             }
             set
             {
-                _ushortArgs = value;
+                _processData = value;
             }
         }
 
-        public string[] strArgs
+    }
+}
+
+
+
+// Before: 
+/*
+public class DeviceDataReceivedEventArgs : EventArgs
+{
+    private ushort[] _ushortArgs;
+    private string[] _strArgs;
+    
+
+    public DeviceDataReceivedEventArgs(ushort[] _ushortArrayParam, string[] _strArrayParam)
+    {
+        _ushortArgs = _ushortArrayParam;
+        _strArgs = _strArrayParam;
+    }
+
+    public ushort[] ushortArgs
+    {
+        get
         {
-            get
-            {
-                return _strArgs;
-            }
-            set
-            {
-                _strArgs = value;
-            }
+            return _ushortArgs;
+        }
+        set
+        {
+            _ushortArgs = value;
+        }
+    }
+
+    public string[] strArgs
+    {
+        get
+        {
+            return _strArgs;
+        }
+        set
+        {
+            _strArgs = value;
         }
     }
 }
+*/

--- a/HBM.Weighing.API/HBM.Weighing.API.csproj
+++ b/HBM.Weighing.API/HBM.Weighing.API.csproj
@@ -66,6 +66,7 @@
     <Compile Include="IDeviceData.cs" />
     <Compile Include="INetConnection.cs" />
     <Compile Include="LogEvent.cs" />
+    <Compile Include="WTX\IProcessData.cs" />
     <Compile Include="WTX\Jet\JetBusConnection.cs" />
     <Compile Include="WTX\Modbus\ModbusTCPConnection.cs" />
     <Compile Include="WTX\WTXJet.cs" />

--- a/HBM.Weighing.API/WTX/IProcessData.cs
+++ b/HBM.Weighing.API/WTX/IProcessData.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+// Stand : 11-12-2018
+
+namespace HBM.Weighing.API.WTX
+{
+    // According to OPC-UA Standard: 
+    /*
+    string WeightId
+    bool GrossNegativ
+    bool CenterOfZero
+    Enum TareMode
+    bool WeightStable
+    uint CurrentRangeId
+    bool Overload
+    bool Underload
+    bool InsideZero
+    bool Invalid
+    bool LegalForTrade
+    'PrintableWeightType erbt von AbstractWeightType' PrintableValue
+    'WeightType erbt von AbstractWeightType' HighResolutionValue
+    */
+
+    interface IProcessData
+    {
+        double NetValue // Gross value of weight 
+        {
+            get;
+        }
+
+        double GrossValue // Net value of weight
+        {
+            get;
+        }
+
+        double Tare // Tare value of weight
+        {
+            get;
+        }
+
+        bool GeneralWeightError
+        {
+            get;
+        }
+
+        bool ScaleAlarmTriggered
+        {
+            get;
+        }
+
+        int LimitStatus
+        {
+            get;
+        }
+
+        bool WeightMoving  // = WeightStable (OPC-UA Standard)
+        {
+            get;
+        }
+
+        bool ScaleSealIsOpen
+        {
+            get;
+        }
+
+        bool ManualTare
+        {
+            get;
+        }
+
+        bool WeightType
+        {
+            get;
+        }
+
+        int ScaleRange // = CurrentRangeId (OPC-UA Standard)
+        {
+            get;
+        }
+
+        bool ZeroRequired
+        {
+            get;
+        }
+
+        bool WeightWithinTheCenterOfZero // = CenterOfZero (OPC-UA Standard)
+        {
+            get;
+        }
+
+        bool WeightInZeroRange // = Inside zero (OPC-UA Standard)
+        {
+            get;
+        }
+
+        int ApplicationMode
+        {
+            get;
+        }
+
+        int Decimals
+        {
+            get;
+        }
+
+        int Unit
+        {
+            get;
+        }
+
+        bool Handshake
+        {
+            get;
+        }
+
+        bool Status
+        {
+            get;
+        }
+
+
+        bool Underload // = Underload (OPC-UA Standard)
+        {
+            get;
+        }
+
+        bool Overload // = Overload (OPC-UA Standard)
+        {
+            get;
+        }
+
+        bool weightWithinLimits 
+        {
+            get;
+        }
+
+        bool higherSafeLoadLimit
+        {
+            get;
+        }
+
+        int LegalTradeOp // = LegalForTrade (OPC-UA Standard)
+        {
+            get;
+        }
+
+    }
+}

--- a/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
@@ -231,7 +231,7 @@ namespace HBM.Weighing.API.WTX.Jet
 
             dataArrived = true;
 
-            IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray, DataStrArray));
+            //IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(new WtxJet(this,Update1)));
         }
 
         protected virtual void WaitOne(int timeoutMultiplier = 1)
@@ -303,12 +303,17 @@ namespace HBM.Weighing.API.WTX.Jet
                 this.ConvertJTokenToStringArray();
               
                 if (dataArrived == true)
-                    IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray, DataStrArray));
-
+                    //IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray, DataStrArray));
+                    IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(null));
                 BusActivityDetection?.Invoke(this, new LogEvent(data.ToString()));
             }
         }
-     
+
+
+        private void Update1(object sender, DeviceDataReceivedEventArgs e)
+        {
+        }
+
         public Dictionary<string, int> getData()
         {
             return _dataIntegerBuffer;
@@ -328,7 +333,8 @@ namespace HBM.Weighing.API.WTX.Jet
 
                     this.ConvertJTokenToStringArray();
                    
-                    IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray,DataStrArray));
+                    //IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray,DataStrArray));
+
 
                     return _dataJTokenBuffer[index.ToString()];
                 }

--- a/HBM.Weighing.API/WTX/WTXJet.cs
+++ b/HBM.Weighing.API/WTX/WTXJet.cs
@@ -158,10 +158,12 @@ namespace HBM.Weighing.API.WTX
 
         public void OnData(object sender, DeviceDataReceivedEventArgs e)
         {
-            this._dataStrArr = new string[e.strArgs.Length];
+            //this._dataStrArr = new string[e.strArgs.Length];
 
             // Do something with the data, like in the class WTXModbus.cs           
-            DataReceived?.Invoke(this, e);
+            //DataReceived?.Invoke(this, e);
+
+            this.DataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(this));
         }
 
         public override string ConnectionType

--- a/HBM.Weighing.API/WTX/WTXModbus.cs
+++ b/HBM.Weighing.API/WTX/WTXModbus.cs
@@ -35,7 +35,7 @@ using System.Timers;
 namespace HBM.Weighing.API.WTX
 {
 
-    public class WtxModbus : BaseWtDevice   
+    public class WtxModbus : BaseWtDevice
     {
         private string[] _dataStr;
         private ushort[] _previousData;
@@ -538,7 +538,9 @@ namespace HBM.Weighing.API.WTX
             {                                                                                                    // and the data should be send to the GUI/console and be printed out. 
                                                                                                                  // If the GUI has been refreshed, the values should also be send to the GUI/Console and be printed out. 
                                                                                                                  //DataUpdateEvent?.Invoke(this, new DataEvent(this._data, this.GetDataStr));
-                this.DataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(this._data, this.GetDataStr));
+                                                                                                                 //this.DataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(this._data, this.GetDataStr));
+
+                this.DataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(this));
 
                 this._isCalibrating = false;
             }

--- a/Tests/JetbusTest/TestJetbusConnection.cs
+++ b/Tests/JetbusTest/TestJetbusConnection.cs
@@ -232,8 +232,8 @@ namespace HBM.Weighing.API.WTX.Jet
             this.ConvertJTokenToStringArray();
 
             if (this.behavior != Behavior.ReadFail_DataReceived)
-                IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray, DataStrArray));
-
+                //IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray, DataStrArray));
+                IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(new WtxJet(this, Update1)));
             return _dataBuffer[index.ToString()];
             
         }
@@ -332,9 +332,14 @@ namespace HBM.Weighing.API.WTX.Jet
             this.ConvertJTokenToStringArray();
 
             if (this.behavior != Behavior.ReadFail_DataReceived)
-                IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray, DataStrArray));
-
+                //IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(DataUshortArray, DataStrArray));
+                IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(new WtxJet(this, Update1)));
             BusActivityDetection?.Invoke(this, new LogEvent("Fetch-All success: " + success + " - buffersize is " + _dataBuffer.Count));            
+        }
+
+        private void Update1(object sender, DeviceDataReceivedEventArgs e)
+        {
+            throw new NotImplementedException();
         }
 
         protected virtual void WaitOne(int timeoutMultiplier = 1)

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -376,9 +376,14 @@ namespace HBM.Weighing.API.WTX.Modbus
                     break;
             }
 
-            IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(this._dataWTX, new string[0]));
-
+            //IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(this._dataWTX, new string[0]));
+            IncomingDataReceived?.Invoke(this, new DeviceDataReceivedEventArgs(new WtxJet(this, Update1)));
             return _dataWTX[Convert.ToInt16(index)];
+        }
+
+        private void Update1(object sender, DeviceDataReceivedEventArgs e)
+        {
+            throw new NotImplementedException();
         }
 
         public int getCommand


### PR DESCRIPTION
DeviceDataReceivedEventArgs: Using interface instead of ushort[],stri…ng[] for data transfer between WTXJet/Modbus and GUI.