### PR TITLE
-Changing the initialisation of _processData,_dataStandard/Filler/Extended from classes to interfaces in BaseWtDevice.  -Adding get-/set-Properties to interface IDataFillerExtended. -_limitValue1/2/3/4 to _limitStatus1/2/3/4. -Adding '#region' to the interfaces.

### DIFF
--- a/HBM.Weighing.API/BaseWTDevice.cs
+++ b/HBM.Weighing.API/BaseWTDevice.cs
@@ -38,10 +38,10 @@ namespace HBM.Weighing.API
 
         protected INetConnection _connection;
 
-        private ProcessData _processData;
-        private DataStandard _dataStandard;
-        private DataFiller _dataFiller;
-        private DataFillerExtended _dataFillerExtended;
+        private IProcessData _processData;
+        private IDataStandard _dataStandard;
+        private IDataFiller _dataFiller;
+        private IDataFillerExtended _dataFillerExtended;
 
         //delegate void ProcessDataReceivedEventHandler(object source, ProcessDataReceivedEventArgs args);
 
@@ -78,7 +78,7 @@ namespace HBM.Weighing.API
         /// <summary>
         /// Get-Property : Class of interface IProcessData containing the real-time data
         /// </summary>
-        public ProcessData ProcessData
+        public IProcessData ProcessData
         {
             get
             {
@@ -86,7 +86,7 @@ namespace HBM.Weighing.API
             }
         }
 
-        public DataStandard DataStandard
+        public IDataStandard DataStandard
         {
             get
             {
@@ -94,7 +94,7 @@ namespace HBM.Weighing.API
             }
         }
 
-        public DataFiller DataFiller
+        public IDataFiller DataFiller
         {
             get
             {
@@ -102,7 +102,7 @@ namespace HBM.Weighing.API
             }
         }
 
-        public DataFillerExtended DataFillerExtended
+        public IDataFillerExtended DataFillerExtended
         {
             get
             {

--- a/HBM.Weighing.API/Data/DataStandard.cs
+++ b/HBM.Weighing.API/Data/DataStandard.cs
@@ -24,10 +24,10 @@ namespace HBM.Weighing.API.Data
         private int _output3;
         private int _output4;
 
-        private int _limitValue1;
-        private int _limitValue2;
-        private int _limitValue3;
-        private int _limitValue4;
+        private int _limitStatus1;
+        private int _limitStatus2;
+        private int _limitStatus3;
+        private int _limitStatus4;
 
         private int _weightMemDay;
         private int _weightMemMonth;
@@ -80,10 +80,10 @@ namespace HBM.Weighing.API.Data
             _output3=0;
             _output4=0;
 
-            _limitValue1=0;
-            _limitValue2=0;
-            _limitValue3=0;
-            _limitValue4=0;
+            _limitStatus1 = 0;
+            _limitStatus2 = 0;
+            _limitStatus3 = 0;
+            _limitStatus4 = 0;
 
             _weightMemDay=0;
             _weightMemMonth=0;
@@ -124,7 +124,7 @@ namespace HBM.Weighing.API.Data
 
         #region Update methods for standard mode
 
-    public void UpdateStandardDataModbus(ushort[] _dataParam)
+        public void UpdateStandardDataModbus(ushort[] _dataParam)
         {
             this._data = _dataParam;
 
@@ -138,10 +138,10 @@ namespace HBM.Weighing.API.Data
             _output3 = ((_data[7] & 0x4) >> 2);
             _output4 = ((_data[7] & 0x8) >> 3);
 
-            _limitValue1 = (_data[8] & 0x1); ;
-            _limitValue2 = ((_data[8] & 0x2) >> 1);
-            _limitValue3 = ((_data[8] & 0x4) >> 2);
-            _limitValue4 = ((_data[8] & 0x8) >> 3);
+            _limitStatus1 = (_data[8] & 0x1); ;
+            _limitStatus2 = ((_data[8] & 0x2) >> 1);
+            _limitStatus3 = ((_data[8] & 0x4) >> 2);
+            _limitStatus4 = ((_data[8] & 0x8) >> 3);
 
             _weightMemDay = (_data[9]);
             _weightMemMonth = (_data[10]);
@@ -195,19 +195,19 @@ namespace HBM.Weighing.API.Data
         }
         public int LimitStatus1
         {
-            get{ return _limitValue1; }
+            get{ return _limitStatus1; }
         }
         public int LimitStatus2
         {
-            get{ return _limitValue2; }
+            get{ return _limitStatus2; }
         }
         public int LimitStatus3
         {
-            get{ return _limitValue3; }
+            get{ return _limitStatus3; }
         }
         public int LimitStatus4
         {
-            get{ return _limitValue4; }
+            get{ return _limitStatus4; }
         }
         public int WeightMemDay
         {
@@ -240,22 +240,6 @@ namespace HBM.Weighing.API.Data
             set { this._weightMemNet = value; }
         }
 
-        public int LimitValue1
-        {
-            get { return _limitValue1; }
-        }
-        public int LimitValue2
-        {
-            get { return _limitValue2; }
-        }
-        public int LimitValue3
-        {
-            get { return _limitValue3; }
-        }
-        public int LimitValue4
-        {
-            get { return _limitValue4; }
-        }
         #endregion
 
         #region Get-/Set-properties for standard mode 

--- a/HBM.Weighing.API/Data/IDataFiller.cs
+++ b/HBM.Weighing.API/Data/IDataFiller.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace HBM.Weighing.API
 {
-    interface IDataFiller
+    public interface IDataFiller
     {
         #region Filler device data - Input words
 
@@ -51,38 +51,38 @@ namespace HBM.Weighing.API
 
         #region Filler device data - Output words
 
-        int ResidualFlowTime { set; }
-        int TargetFillingWeight { set; }
-        int CoarseFlowCutOffPointSet { set; }
-        int FineFlowCutOffPointSet { set; }
+        int ResidualFlowTime { get; set; }
+        int TargetFillingWeight { get;  set; }
+        int CoarseFlowCutOffPointSet { get;  set; }
+        int FineFlowCutOffPointSet { get;  set; }
 
-        int MinimumFineFlow { set; }
-        int OptimizationOfCutOffPoints { set; }
-        int MaximumDosingTime { set; }
-        int StartWithFineFlow { set; }
+        int MinimumFineFlow { get;  set; }
+        int OptimizationOfCutOffPoints { get;  set; }
+        int MaximumDosingTime { get;  set; }
+        int StartWithFineFlow { get;  set; }
 
-        int CoarseLockoutTime { set; }
-        int FineLockoutTime { set; }
-        int TareMode { set; }
-        int UpperToleranceLimit { set; }
+        int CoarseLockoutTime { get;  set; }
+        int FineLockoutTime { get;  set; }
+        int TareMode { get;  set; }
+        int UpperToleranceLimit { get;  set; }
 
-        int LowerToleranceLimit { set; }
-        int MinimumStartWeight { set; }
-        int EmptyWeight { set; }
-        int TareDelay { set; }
+        int LowerToleranceLimit { get;  set; }
+        int MinimumStartWeight { get;  set; }
+        int EmptyWeight { get;  set; }
+        int TareDelay { get;  set; }
 
-        int CoarseFlowMonitoringTime { set; }
-        int CoarseFlowMonitoring { set; }
-        int FineFlowMonitoring { set; }
-        int FineFlowMonitoringTime { set; }
+        int CoarseFlowMonitoringTime { get;  set; }
+        int CoarseFlowMonitoring { get;  set; }
+        int FineFlowMonitoring { get;  set; }
+        int FineFlowMonitoringTime { get;  set; }
 
-        int DelayTimeAfterFineFlow { set; }
-        int ActivationTimeAfterFineFlow { set; }
-        int SystematicDifference { set; }
-        int DownwardsDosing { set; }
+        int DelayTimeAfterFineFlow { get;  set; }
+        int ActivationTimeAfterFineFlow { get;  set; }
+        int SystematicDifference { get;  set; }
+        int DownwardsDosing { get;  set; }
 
-        int ValveControl { set; }
-        int EmptyingMode { set; }
+        int ValveControl { get;  set; }
+        int EmptyingMode { get;  set; }
         #endregion
 
         #region Filler device data - Input and output words
@@ -92,5 +92,11 @@ namespace HBM.Weighing.API
 
         #endregion
 
+        #region Update methods for the data of standard mode
+
+        void UpdateFillerDataModbus(ushort[] _dataParam);
+        void UpdateFillerDataJet(Dictionary<string, int> _dataParam);
+
+        #endregion
     }
 }

--- a/HBM.Weighing.API/Data/IDataFillerExtended.cs
+++ b/HBM.Weighing.API/Data/IDataFillerExtended.cs
@@ -6,7 +6,50 @@ using System.Threading.Tasks;
 
 namespace HBM.Weighing.API
 {
-    interface IDataFillerExtended : IDataFiller
+    public interface IDataFillerExtended : IDataFiller
     {
+        #region Output words for the data of filler extended mode
+
+        int ResidualFlowTime { get;  set; }
+        int TargetFillingWeight { get;  set; }
+        int CoarseFlowCutOffPointSet { get;  set; }
+        int FineFlowCutOffPointSet { get;  set; }
+
+        int MinimumFineFlow { get;  set; }
+        int OptimizationOfCutOffPoints { get;  set; }
+        int MaximumDosingTime { get;  set; }
+        int StartWithFineFlow { get;  set; }
+
+        int CoarseLockoutTime { get;  set; }
+        int FineLockoutTime { get;  set; }
+        int TareMode { get;  set; }
+        int UpperToleranceLimit { get;  set; }
+
+        int LowerToleranceLimit { get;  set; }
+        int MinimumStartWeight { get;  set; }
+        int EmptyWeight { get;  set; }
+        int TareDelay { get;  set; }
+
+        int CoarseFlowMonitoringTime { get;  set; }
+        int CoarseFlowMonitoring { get;  set; }
+        int FineFlowMonitoring { get;  set; }
+        int FineFlowMonitoringTime { get;  set; }
+
+        int DelayTimeAfterFineFlow { get;  set; }
+        int ActivationTimeAfterFineFlow { get;  set; }
+        int SystematicDifference { get;  set; }
+        int DownwardsDosing { get;  set; }
+
+        int ValveControl { get;  set; }
+        int EmptyingMode { get;  set; }
+
+        #endregion 
+
+        #region Update methods for the data of filler extended mode
+
+        void UpdateFillerExtendedDataModbus(ushort[] _dataParam);
+        void UpdateFillerExtendedDataJet(Dictionary<string, int> _dataParam);
+
+        #endregion
     }
 }

--- a/HBM.Weighing.API/Data/IDataStandard.cs
+++ b/HBM.Weighing.API/Data/IDataStandard.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace HBM.Weighing.API
 {
-    interface IDataStandard 
+    public interface IDataStandard 
     {
         #region Input words for standard mode
 
@@ -20,10 +20,10 @@ namespace HBM.Weighing.API
         int Output3 { get; }
         int Output4 { get; }
 
-        int LimitValue1 { get; }
-        int LimitValue2 { get; }
-        int LimitValue3 { get; }
-        int LimitValue4 { get; }
+        int LimitStatus1 { get; }
+        int LimitStatus2 { get; }
+        int LimitStatus3 { get; }
+        int LimitStatus4 { get; }
 
         int WeightMemDay      { get; set; }
         int WeightMemMonth    { get; set; }
@@ -61,6 +61,13 @@ namespace HBM.Weighing.API
         int CalibrationWeight { get;  set; }
         int ZeroLoad { get;  set; }
         int NominalLoad { get;  set; }
+
+        #endregion
+
+        #region Update methods for the data of standard mode
+
+        void UpdateStandardDataModbus(ushort[] _dataParam);
+        void UpdateStandardDataJet(Dictionary<string, int> _dataParam);
 
         #endregion
     }

--- a/HBM.Weighing.API/Data/IProcessData.cs
+++ b/HBM.Weighing.API/Data/IProcessData.cs
@@ -30,12 +30,16 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 
 namespace HBM.Weighing.API
 {
 
     public interface IProcessData
     {
+
+        #region Process device data 
+
         int NetValue { get; } // Net value of weight 
         string NetValueStr { get; }
         int GrossValue { get; } // Gross value of weight
@@ -63,10 +67,19 @@ namespace HBM.Weighing.API
 
         bool Handshake { get; }
         bool Status { get; }
-        bool Underload{ get; } // = Underload (OPC-UA Standard)
-        bool Overload { get; } // = Overload (OPC-UA Standard)
+        bool Underload{ get; set; } // = Underload (OPC-UA Standard)
+        bool Overload { get; set; } // = Overload (OPC-UA Standard)
 
-        bool weightWithinLimits { get; }
-        bool higherSafeLoadLimit { get; }
+        bool weightWithinLimits { get; set; }
+        bool higherSafeLoadLimit{ get; set; }
+
+        #endregion
+
+        #region Update methods for the process data
+
+        void UpdateProcessDataModbus(ushort[] _dataParam);
+        void UpdateProcessDataJet(Dictionary<string, int> _dataParam);
+
+        #endregion
     }
 }

--- a/HBM.Weighing.API/ProcessDataReceivedEventArgs.cs
+++ b/HBM.Weighing.API/ProcessDataReceivedEventArgs.cs
@@ -36,7 +36,7 @@ namespace HBM.Weighing.API
     {
         IProcessData _processData;
 
-        public ProcessDataReceivedEventArgs(ProcessData processData)
+        public ProcessDataReceivedEventArgs(IProcessData processData)
         {
             ProcessData = processData;
         }

--- a/HBM.Weighing.API/WTX/WTXJet.cs
+++ b/HBM.Weighing.API/WTX/WTXJet.cs
@@ -37,7 +37,7 @@ namespace HBM.Weighing.API.WTX
 {
     public class WtxJet : BaseWtDevice
     {
-        #region Const
+        #region Constants
         private const int CONVERISION_FACTOR_MVV_TO_D = 500000; //   2 / 1000000; // 2mV/V correspond 1 million digits (d)   
 
         private const int SCALE_COMMAND_CALIBRATE_ZERO = 2053923171;
@@ -53,10 +53,6 @@ namespace HBM.Weighing.API.WTX
         private const int SCALE_COMMAND_STATUS_ERROR_E1 = 826629983;
         private const int SCALE_COMMAND_STATUS_ERROR_E2 = 843407199;
         private const int SCALE_COMMAND_STATUS_ERROR_E3 = 860184415;
-        #endregion
-
-        #region Privates 
-
         #endregion
 
         #region Events


### PR DESCRIPTION
-Changing the initialisation of _processData,_dataStandard/Filler/Extended from classes to interfaces in BaseWtDevice.  

-Adding get-/set-Properties to interface IDataFillerExtended. 

-_limitValue1/2/3/4 to _limitStatus1/2/3/4. 

-Adding '#region's to the interfaces.