### PR TITLE
-Renaming and translation of command ID's for Jetbus in JetBusCommands.cs.  -Adding comment methods to BaseWtDevice.cs for inheritance from WTXJet and WTXModbus. -Changing the datatype from boolean to integer of IProcessData-attribute 'status' (f.e. for Jetbus values for status = 1801...). -Putting method limitStatusBool() to class ProcessData for its immediate update. -Enabling data update of the filler attributes via Jetbus (with IMD-Input mode ID for standard/filler mode check). -Adding and renaming copyrights.

### DIFF
--- a/Examples/CommandLine/Program.cs
+++ b/Examples/CommandLine/Program.cs
@@ -439,12 +439,12 @@ namespace WTXModbus
             {
                 Console.Clear();               
 
-                if (e.ProcessData.ApplicationMode == 0)  // If the WTX device is in standard application/mode.
+                if (e.ProcessData.ApplicationMode == 0 || e.ProcessData.ApplicationMode == 1)  // If the WTX device is in standard application/mode.
                 {
                     Console.WriteLine("0-Taring | 1-Gross/net   | 2-Zeroing  | 3- Adjust zero    | 4-Adjust nominal |\n5-Activate Data          | 6-Manual taring                | 7-Weight storage | \nj-Connection to Jetbus   | a-Show all input words 0 to 37 |\no-Show output words 9-44 | b-Bytes read from the register |\nc-Calculate Calibration  | w-Calibration with weight      | e-Exit\n");
                 }
                 else
-                    if (e.ProcessData.ApplicationMode == 1 || e.ProcessData.ApplicationMode == 2) // If the WTX device is in filler application/mode.
+                    if (e.ProcessData.ApplicationMode == 2 || e.ProcessData.ApplicationMode == 3) // If the WTX device is in filler application/mode.
                     {
 
                     if(_showAllInputWords==false && mode=="Modbus")
@@ -458,7 +458,7 @@ namespace WTXModbus
 
                 }
 
-                if (e.ProcessData.ApplicationMode == 0)   // If the device is in the standard mode (standard=0; filler=1 or filler=2) 
+                if (e.ProcessData.ApplicationMode == 0 || e.ProcessData.ApplicationMode == 1)   // If the device is in the standard mode (standard=0 or standard=1; filler=1 or filler=2) 
                 {
 
                     // The values are printed on the console according to the input - "numInputs": 
@@ -482,14 +482,14 @@ namespace WTXModbus
                         Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +        "\t  As an Integer:  " + e.ProcessData.LimitStatus);
                         Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() +    "\t  As an Integer:  " + e.ProcessData.ScaleSealIsOpen);
                         Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +         "\t  As an Integer:  " + e.ProcessData.ManualTare);
-                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an Integer:  " + e.ProcessData.WeightType);        //e.ProcessData.WeightTypeStringComment()
-                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an Integer:  " + e.ProcessData.ScaleRange);        //e.ProcessData.ScaleRangeStringComment()
+                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an Integer:  " + e.ProcessData.WeightType);
+                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an Integer:  " + e.ProcessData.ScaleRange);
                         Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +       "\t  As an Integer:  " + e.ProcessData.ZeroRequired);
                         Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightWithinTheCenterOfZero);
                         Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() +  "\t  As an Integer:  " + e.ProcessData.WeightInZeroRange);
 
-                        Console.WriteLine("Limit status:                  " + e.ProcessData.LimitStatus.ToString() + "        As an Integer:  " + e.ProcessData.LimitStatus);               //e.ProcessData.LimitStatusStringComment()
-                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an Integer: " + e.ProcessData.WeightMoving);                //e.ProcessData.WeightMovingStringComment()
+                        Console.WriteLine("Limit status:                  " + e.ProcessData.LimitStatus.ToString() + "        As an Integer:  " + e.ProcessData.LimitStatus);
+                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an Integer: " + e.ProcessData.WeightMoving);
                     }
                     else
                     if (_inputMode == 6 || _inputMode == 38)
@@ -500,46 +500,46 @@ namespace WTXModbus
                         Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +                         "\t  As an Integer:  " + e.ProcessData.LimitStatus);
                         Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() +                     "\t  As an Integer:  " + e.ProcessData.ScaleSealIsOpen);
                         Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +        "\t  As an Integer:  " + e.ProcessData.ManualTare);
-                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an Integer:  " + e.ProcessData.WeightType);        //e.ProcessData.WeightTypeStringComment()
-                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an Integer:  " + e.ProcessData.ScaleRange);        //e.ProcessData.ScaleRangeStringComment()
+                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an Integer:  " + e.ProcessData.WeightType);
+                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an Integer:  " + e.ProcessData.ScaleRange);
                         Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +      "\t  As an Integer:  " + e.ProcessData.ZeroRequired);
                         Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightWithinTheCenterOfZero);
                         Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightInZeroRange);
-                        Console.WriteLine("Application mode:              " + e.ProcessData.ApplicationMode.ToString() + "\t  As an Integer:  " + e.ProcessData.ApplicationMode);  //e.ProcessData.ApplicationModeStringComment()
+                        Console.WriteLine("Application mode:              " + _wtxDevice.ApplicationModeStringComment() + "\t  As an Integer:  " + e.ProcessData.ApplicationMode);
                         Console.WriteLine("Decimal places:                " + e.ProcessData.Decimals.ToString() +          "\t  As an Integer:  " + e.ProcessData.Decimals);
                         Console.WriteLine("Unit:                          " + _wtxDevice.UnitStringComment() +                       "\t  As an Integer:  " + e.ProcessData.Unit);
                         Console.WriteLine("Handshake:                     " + e.ProcessData.Handshake.ToString() +         "\t  As an Integer:  " + e.ProcessData.Handshake);
-                        Console.WriteLine("Status:                        " + statusCommentMethod() + "\t  As an Integer:  " + e.ProcessData.Status);     //e.ProcessData.StatusStringComment()
+                        Console.WriteLine("Status:                        " + statusCommentMethod() + "\t  As an Integer:  " + e.ProcessData.Status);
 
-                        Console.WriteLine("Limit status:                  " + limitCommentMethod() + "       As an Integer:  " + e.ProcessData.LimitStatus);               //e.ProcessData.LimitStatusStringComment()
-                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "         As an Integer: " + e.ProcessData.WeightMoving);                //e.ProcessData.WeightMovingStringComment()
+                        Console.WriteLine("Limit status:                  " + limitCommentMethod() + "       As an Integer:  " + e.ProcessData.LimitStatus);
+                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "         As an Integer: " + e.ProcessData.WeightMoving);
 
                     }
                     else
                         Console.WriteLine("\nWrong input for the number of bytes, which should be read from the register!\nPlease enter 'b' to choose again.");
                 }
                 else
-                    if (e.ProcessData.ApplicationMode == 2 || e.ProcessData.ApplicationMode == 1)
-                    {
+                    if (e.ProcessData.ApplicationMode == 2 || e.ProcessData.ApplicationMode == 3)      // If the device is in the filler mode (standard=0 or standard=1; filler=2 or filler=3) 
+                {
                     Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +   "\t  As an Integer:  " + e.ProcessData.NetValue);
                     Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + "\t  As an Integer:  " + e.ProcessData.GrossValue);
                     Console.WriteLine("General weight error:          " + e.ProcessData.GeneralWeightError.ToString() +                   "\t  As an Integer:  " + e.ProcessData.GeneralWeightError);
                     Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +     "\t  As an Integer:  " + e.ProcessData.LimitStatus);
                     Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() + "\t  As an Integer:  " + e.ProcessData.ScaleSealIsOpen);
                     Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +      "\t  As an Integer:  " + e.ProcessData.ManualTare);
-                    Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType +               "\t  As an Integer:  " + e.ProcessData.WeightType);        //e.ProcessData.WeightTypeStringComment()
-                    Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange +               "\t  As an Integer:  " + e.ProcessData.ScaleRange);        //e.ProcessData.ScaleRangeStringComment()
+                    Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType +               "\t  As an Integer:  " + e.ProcessData.WeightType);
+                    Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange +               "\t  As an Integer:  " + e.ProcessData.ScaleRange);
                     Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +    "\t  As an Integer:  " + e.ProcessData.ZeroRequired);
                     Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightWithinTheCenterOfZero);
                     Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() +           "\t  As an Integer:  " + e.ProcessData.WeightInZeroRange);
-                    Console.WriteLine("Application mode:              " + e.ProcessData.ApplicationMode.ToString() +           "\t  As an Integer:  " + e.ProcessData.ApplicationMode);  //e.ProcessData.ApplicationModeStringComment()
+                    Console.WriteLine("Application mode:              " + _wtxDevice.ApplicationModeStringComment() +           "\t  As an Integer:  " + e.ProcessData.ApplicationMode);
                     Console.WriteLine("Decimal places:                " + e.ProcessData.Decimals.ToString() +         "\t  As an Integer:  " + e.ProcessData.Decimals);
                     Console.WriteLine("Unit:                          " + _wtxDevice.UnitStringComment() +                      "\t  As an Integer:  " + e.ProcessData.Unit);
                     Console.WriteLine("Handshake:                     " + e.ProcessData.Handshake.ToString() +        "\t  As an Integer:  " + e.ProcessData.Handshake);
-                    Console.WriteLine("Status:                        " + statusCommentMethod() +                    "\t  As an Integer:  " + e.ProcessData.Status);     //e.ProcessData.StatusStringComment()
+                    Console.WriteLine("Status:                        " + statusCommentMethod() +                    "\t  As an Integer:  " + e.ProcessData.Status);
 
-                    Console.WriteLine("Limit status:                  " + limitCommentMethod() +  "     As an Integer:  " + e.ProcessData.LimitStatus);               //e.ProcessData.LimitStatusStringComment()
-                    Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an Integer:  " + e.ProcessData.WeightMoving);                //e.ProcessData.WeightMovingStringComment()
+                    Console.WriteLine("Limit status:                  " + limitCommentMethod() +  "     As an Integer:  " + e.ProcessData.LimitStatus);
+                    Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an Integer:  " + e.ProcessData.WeightMoving);
 
                     if (_showAllInputWords == true)
                     {
@@ -646,19 +646,19 @@ namespace WTXModbus
 
             if (mode == "Jetbus" || mode == "Jet" || mode == "jet" || mode == "jetbus")
             {
-                if (_wtxDevice.ProcessData.Status == false) // 1634168417 = false
+                if (_wtxDevice.ProcessData.Status == 0) // 1634168417 = false
                     return "Command on go";
 
-                if (_wtxDevice.ProcessData.Status == true) // 1801543519 = true
+                if (_wtxDevice.ProcessData.Status == 1) // 1801543519 = true
                     return "Command ok";
             }
             else
                 if (mode == "Modbus" || mode == "modbus")
                 {
-                    if (_wtxDevice.ProcessData.Status == false)
+                    if (_wtxDevice.ProcessData.Status == 0)
                         return "Command on go";
 
-                    if (_wtxDevice.ProcessData.Status == true)
+                    if (_wtxDevice.ProcessData.Status == 1)
                         return "Command ok";
                  }
             return "Command on go";
@@ -682,6 +682,19 @@ namespace WTXModbus
             }
         }
 
+        public static string ApplicationModeStringComment()
+        {
+            if (_wtxDevice.ProcessData.ApplicationMode == 0 || _wtxDevice.ProcessData.ApplicationMode == 1)
+                return "Standard";
+            else
+
+                if (_wtxDevice.ProcessData.ApplicationMode == 2 || _wtxDevice.ProcessData.ApplicationMode == 3)
+                return "Filler";
+            else
+
+                return "error";
+        }
+
         private static void zero_load_nominal_load_input()
         {
 
@@ -691,14 +704,14 @@ namespace WTXModbus
 
             string _preloadStr = Console.ReadLine();
             _strCommaDot = _preloadStr.Replace(".", ",");           // For converting into a floating-point number.
-            _preload = double.Parse(_strCommaDot);                   // By using the method 'double.Parse(..)' you can use dots and commas.
+            _preload = double.Parse(_strCommaDot);                  // By using the method 'double.Parse(..)' you can use dots and commas.
 
 
             Console.WriteLine("\nPlease tip the value for the span/nominal load and tip enter to confirm : ");
 
             string _capacityStr = Console.ReadLine();
             _strCommaDot = _capacityStr.Replace(".", ",");           // For converting into a floating-point number.
-            _capacity = double.Parse(_strCommaDot);                   // By using the method 'double.Parse(..)' you can use dots and commas.
+            _capacity = double.Parse(_strCommaDot);                  // By using the method 'double.Parse(..)' you can use dots and commas.
 
         }
         #endregion

--- a/HBM.Weighing.API/BaseWTDevice.cs
+++ b/HBM.Weighing.API/BaseWTDevice.cs
@@ -193,11 +193,35 @@ namespace HBM.Weighing.API
         public abstract string ConnectionType { get; }
 
         /// <summary>
-        /// Sets the unit according to an integer value 
+        /// Sets the unit according to an integer value : g, kg, lb, t 
         /// </summary>
         /// <returns></returns>
         public abstract string UnitStringComment();
         #endregion
+
+        /// <summary>
+        /// Sets the status according according to the integer value in ProcessData : F.e. "Execution OK!" or "Execution not OK!"
+        /// </summary>
+        /// <returns></returns>
+        public abstract string StatusStringComment();
+
+        /// <summary>
+        /// Sets the application mode according to the integer value in ProcessData : Standard or filler mode
+        /// </summary>
+        /// <returns></returns>
+        public abstract string ApplicationModeStringComment();
+
+        /// <summary>
+        /// Sets the weight type according to the integer value in ProcessData: gross or net
+        /// </summary>
+        /// <returns></returns>
+        public abstract string WeightTypeStringComment();
+
+        /// <summary>
+        /// Sets the scale range according to the integer value in ProcessData : Range 1, 2, 3
+        /// </summary>
+        /// <returns></returns>
+        public abstract string ScaleRangeStringComment();
 
     }
 }

--- a/HBM.Weighing.API/Data/DataFiller.cs
+++ b/HBM.Weighing.API/Data/DataFiller.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JetBusConnection.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="DataFiller.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
 //
@@ -280,7 +280,7 @@ namespace HBM.Weighing.API.Data
 
         public void UpdateFillerDataJet(Dictionary<string, int> _data)
         {
-            _maxDosingTime = _data[JetBusCommands.MAXIMUM_DOSING_TIME];
+            _maxDosingTime = _data[JetBusCommands.MAXIMAL_DOSING_TIME];
             _meanValueDosingResults = _data[JetBusCommands.MEAN_VALUE_DOSING_RESULTS];
             _standardDeviation = _data[JetBusCommands.STANDARD_DEVIATION];
             _fineFlowCutOffPoint = _data[JetBusCommands.FINE_FLOW_CUT_OFF_POINT];
@@ -295,7 +295,7 @@ namespace HBM.Weighing.API.Data
             _upperToleranceLimit = _data[JetBusCommands.UPPER_TOLERANCE_LIMIT];
             _lowerToleranceLimit = _data[JetBusCommands.LOWER_TOLERANCE_LOMIT];
             _minimumStartWeight = _data[JetBusCommands.MINIMUM_START_WEIGHT];
-            _emptyWeight = _data[JetBusCommands.EMPTY_WEIGHT];
+            _emptyWeight = _data[JetBusCommands.EMPTY_WEIGHT_TOLERANCE];
             _tareDelay = _data[JetBusCommands.TARE_DELAY];
             _coarseFlowMonitoringTime = _data[JetBusCommands.COARSE_FLOW_MONITORING_TIME];
             _coarseFlowMonitoring = _data[JetBusCommands.COARSE_FLOW_MONITORING];
@@ -305,7 +305,7 @@ namespace HBM.Weighing.API.Data
             _valveControl = _data[JetBusCommands.VALVE_CONTROL];
             _emptyingMode = _data[JetBusCommands.EMPTYING_MODE];
             _delayTimeAfterFineFlow = _data[JetBusCommands.DELAY1_DOSING];
-            _activationTimeAfterFineFlow = _data[JetBusCommands.FINEFLOW_PHASE_BEFORE_COARSEFLOW];
+            _activationTimeAfterFineFlow = _data[JetBusCommands.FINE_FLOW_PHASE_BEFORE_COARSE_FLOW];
 
             // Undefined ID's: 
 

--- a/HBM.Weighing.API/Data/DataFillerExtended.cs
+++ b/HBM.Weighing.API/Data/DataFillerExtended.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JetBusConnection.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="DataFillerExtended.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
 //

--- a/HBM.Weighing.API/Data/DataStandard.cs
+++ b/HBM.Weighing.API/Data/DataStandard.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JetBusConnection.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="DataStandard.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
 //

--- a/HBM.Weighing.API/Data/IDataFiller.cs
+++ b/HBM.Weighing.API/Data/IDataFiller.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JetBusConnection.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="IDataFiller.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
 //

--- a/HBM.Weighing.API/Data/IDataFillerExtended.cs
+++ b/HBM.Weighing.API/Data/IDataFillerExtended.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JetBusConnection.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="IDataFillerExtended.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
 //

--- a/HBM.Weighing.API/Data/IDataStandard.cs
+++ b/HBM.Weighing.API/Data/IDataStandard.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JetBusConnection.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="IDataStandard.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
 //

--- a/HBM.Weighing.API/Data/IProcessData.cs
+++ b/HBM.Weighing.API/Data/IProcessData.cs
@@ -1,5 +1,4 @@
-﻿
-// <copyright file="IDeviceData.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="IProcessData.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
 //
@@ -68,7 +67,7 @@ namespace HBM.Weighing.API
         int Unit { get; }
 
         bool Handshake { get; }
-        bool Status { get; }
+        int Status { get; }
         bool Underload{ get; set; } // = Underload (OPC-UA Standard)
         bool Overload { get; set; } // = Overload (OPC-UA Standard)
 

--- a/HBM.Weighing.API/WTX/Jet/JetBusCommands.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusCommands.cs
@@ -1,4 +1,34 @@
-﻿using System;
+﻿// <copyright file="JetBusCommands.cs" company="Hottinger Baldwin Messtechnik GmbH">
+//
+// HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
+//
+// The MIT License (MIT)
+//
+// Copyright (C) Hottinger Baldwin Messtechnik GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// </copyright>
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,6 +42,15 @@ namespace HBM.Weighing.API.WTX.Jet
     /// </summary>
     struct JetBusCommands
     {
+
+        #region ID Commands : Maintenance - Calibration
+
+        public const string LDW_DEAD_WEIGHT = "2110/06";                // LDW = Nullpunkt
+        public const string LWT_NOMINAL_VALUE = "2110/07";              // LWT = Nennwert
+        public const string LFT_SCALE_CALIBRATION_WEIGHT = "6152/00";   // LFT = LFT scale calibration weight
+
+        #endregion
+
         #region ID commands for process data
         public const string NET_VALUE = "601A/01";
         public const string GROSS_VALUE = "6144/00";
@@ -20,6 +59,8 @@ namespace HBM.Weighing.API.WTX.Jet
         public const string TARE_VALUE = "6143/00";
         public const string WEIGHING_DEVICE_1_WEIGHT_STATUS = "6012/01";
         public const string UNIT_PREFIX_FIXED_PARAMETER = "6014/01";
+
+        public const string APPLICATION_MODE = "2010/07"; // IMD = Input mode ( Application mode)
 
         public const string DECIMALS = "6013/01";
         public const string SCALE_COMMAND = "6002/01";
@@ -42,61 +83,68 @@ namespace HBM.Weighing.API.WTX.Jet
         #endregion
 
         #region ID commands for filler data
-        public const string DOSING_COUNTER = "2230/05";
-        public const string DOSING_STATUS = "2D00/02";  // SDO
-        public const string DOSING_RESULT = "2000/05";  // FRS1      
-        public const string LDW_DEAD_WEIGHT = "2110/06";
 
-        public const string LWT_NOMINAL_VALUE = "2110/07";
-        public const string LFT_SCALE_CALIBRATION_WEIGHT = "6152/00";
-        public const string FUNCTION_DIGITAL_INPUT_1 = "2022/01";  // IM1
-        public const string FUNCTION_DIGITAL_INPUT_2 = "2022/02";  // IM2
+        public const string BREAK_DOSING = "2240/01";                // BRK = Abbruch Dosierung
+        public const string COARSE_FLOW_MONITORING = "2210/01";      // CBK = Füllstromüberwachung Grobstrom
+        public const string COARSE_FLOW_MONITORING_TIME = "2220/01"; // CBT = Überwachungszeit Grobstrom
+        public const string COARSE_FLOW_CUT_OFF_POINT = "2210/02";   // CFD = Grobstromabschaltpunkt
+        public const string COARSE_FLOW_TIME = "2230/01";            // CFT = Grobstromzeit
+        public const string DELETE_DOSING_RESULT = "2230/02";        // CSN = Löschen Dosierergebniss
+        public const string DELAY1_DOSING = "2220/0B";               // DL1 = Delay 1 für Dosieren
+        public const string DELAY2_DOSING = "2220/0C";               // DL2 = Delay 2 für Dosieren
+        public const string DOSING_MODE = "2200/04";                 // DMD = Dosiermodus
+        public const string DOSING_TIME = "2230/03";                 // DST = Dosieristzeit
+        public const string EMPTYING_MODE = "2200/05";               // EMD = Entleermodus
+        public const string DISCHARGE_TIME = "2220/02";              // EPT = Entleerzeit
 
-        public const string FUNCTION_DIGITAL_INPUT_3 = "2022/03";  // IM3
-        public const string FUNCTION_DIGITAL_INPUT_4 = "2022/04";  // IM4
-        public const string FUNCTION_DIGITAL_OUTPUT_1 = "2021/01"; // OM1
-        public const string FUNCTION_DIGITAL_OUTPUT_2 = "2021/02"; // OM2
+        public const string EXCEEDING_WEIGHT_BREAK = "2200/0F";      // EWB = Dosierabbruch bei Leergewichtsüberschreitung
+        public const string EMPTY_WEIGHT_TOLERANCE = "2210/03";      // EWT = Entleertoleranz
+        public const string FINE_FLOW_MONITORING = "2210/04";        // FBK = Füllstromüberwachung Feinstrom
+        public const string FINE_FLOW_MONITORING_TIME = "2220/03";   // FBT = Überwachungszeit Feinstrom
+        public const string FINE_FLOW_CUT_OFF_POINT = "2210/05";     // FFD = Feinstromabschaltpunkt
+        public const string FINE_FLOW_PHASE_BEFORE_COARSE_FLOW = "2220/0A"; // FFL = Feinstromphase vor Grobstrom
+        public const string MINIMUM_FINE_FLOW = "2210/06";           // FFM = Minimaler Feinstromanteil
 
-        public const string FUNCTION_DIGITAL_OUTPUT_3 = "2021/03"; // OM3
-        public const string FUNCTION_DIGITAL_OUTPUT_4 = "2021/04"; // OM4
-        public const string COARSE_FLOW_TIME = "2230/01";            // CFT
-        public const string FINE_FLOW_TIME = "2230/04";              // FFT
+        public const string FINE_FLOW_TIME = "2230/04";              // FFT = Feinstromzeit
+        public const string DOSING_RESULT = "2000/05";               // FRS1 = Dosierergebnis
+        public const string DOSING_STATE = "2000/06";                // FRS2 = Dosierstatus
+        public const string REFERENCE_VALUE_DOSING = "2210/07";      // FWT = Sollwert dosieren
+        public const string LOCKOUT_TIME_COARSE_FLOW = "2220/04";    // LTC = Sperrzeit Grobstrom
+        public const string LOCKOUT_TIME_FINE_FLOW = "2220/05";      // LTF = Sperrzeit Feinstrom
+        public const string LOWER_TOLERANCE_LOMIT = "2210/08";       // LTL = Untere Toleranz
+        public const string MAXIMAL_DOSING_TIME = "2220/06";         // MDT = Maximale Dosierzeit
+        public const string MATERIAL_STREAM_LAST_DOSING = "2000/0E"; // MFO = Materialstrom des letzten Dosierzyklus
+        public const string MINIMUM_START_WEIGHT = "2210/0B";        // MSW = Minimum Startgewicht
+        public const string DOSING_COUNTER = "2230/05";              // NDS = Dosierzähler
+        public const string OPTIMIZATION = "2200/07";                // OSN = Optimierung
+        public const string RANGE_SELECTION_PARAMETER = "2200/02";   // RDP = Auswahl Dosierparameter
 
-        public const string TARE_MODE = "2200/0B";                   // TMD
-        public const string UPPER_TOLERANCE_LIMIT = "2210/0A";       // UTL
-        public const string LOWER_TOLERANCE_LOMIT = "2210/08";       // LTL
-        public const string MINIMUM_START_WEIGHT = "2210/0B";        // MSW
+        public const string REDOSING = "2200/08";                    // RDS = Nachdosieren
+        public const string RESIDUAL_FLOW_DOSING_CYCLE = "2000/0F";  // RFO = Nachstrom des letzten Dosierzyklus
+        public const string RESIDUAL_FLOW_TIME = "2220/07";          // RFT = Nachstromzeit
+        public const string RUN_START_DOSING = "2240/02";            // RUN = Start Dosieren
+        public const string SPECIAL_DOSING_FUNCTIONS = "2200/0A";    // SDF = Sonderfunktionen
+        public const string MEAN_VALUE_DOSING_RESULTS = "2230/06";   // SDM = Mittelwert Dosieren
 
-        public const string EMPTY_WEIGHT = "2210/03";                // EWT
-        public const string TARE_DELAY = "2220/09";                  // TAD
-        public const string COARSE_FLOW_MONITORING_TIME = "2220/01"; // CBT
-        public const string COARSE_FLOW_MONITORING = "2210/01";      // CBK
+        public const string DOSING_STATE_FILLER = "2D00/02";               // SDO = Dosierstatus
+        public const string STANDARD_DEVIATION = "2230/07";                // SDS = Standardabweichung
+        public const string SETTLING_TIME_TRANSIENT_RESPONSE = "2220/08";  // STT = Beruhigungszeit
+        public const string SUM = "2230/08";                               // SUM = Summe
+        public const string SYSTEMATIC_DIFFERENCE = "2210/09";             // SYD = Systematische Differenz
+        public const string TARE_DELAY = "2220/09";                        // TAD = Tarierverzögerung
+        public const string TARE_MODE = "2200/0B";                         // TMD = Tariermodus
+        public const string UPPER_TOLERANCE_LIMIT = "2210/0A";             // UTL = Obere Toleranz
 
-        public const string FINE_FLOW_MONITORING = "2210/04";        // FBK
-        public const string FINE_FLOW_MONITORING_TIME = "2220/03";   // FBT
-        public const string SYSTEMATIC_DIFFERENCE = "2210/09";       // SYD
-        public const string VALVE_CONTROL = "2200/0C";               // VCT
-
-        public const string EMPTYING_MODE = "2200/05";               // EMD
-        public const string COARSE_FLOW_CUT_OFF_POINT = "2210/02";   // CFD
-        public const string FINE_FLOW_CUT_OFF_POINT = "2210/05";     // FFD
-        public const string MEAN_VALUE_DOSING_RESULTS = "2230/06";   // SDM
-
-        public const string STANDARD_DEVIATION = "2230/07";          // SDS
-        public const string RESIDUAL_FLOW_TIME = "2220/07";          // RFT
-        public const string MAXIMUM_DOSING_TIME = "2220/06";         // MDT
-        public const string MINIMUM_FINE_FLOW = "2210/06";           // FFM
-
-        public const string OPTIMIZATION = "2200/07";                // OSN
-        public const string FINEFLOW_PHASE_BEFORE_COARSEFLOW = "2220/0A"; // FFL
-        public const string DELETE_DOSING_RESULT = "2230/02";             // CSN
-        public const string DELAY1_DOSING = "2220/0B"; // DL1
-        public const string DELAY2_DOSING = "2220/0C"; // DL2
+        public const string VALVE_CONTROL = "2200/0C";               // VCT = Ventilsteuerung
+        public const string WRITE_DOSING_PARAMETER_SET = "2200/01";  // WDP = Dosierparametersatz schreiben
+        public const string STORAGE_WEIGHT = "2040/05";              // STO = Gewichtsspeicherung
+        public const string STORAGE_WEIGHT_MODE = "2300/08";         // SMD = Modus Gewichtsspeicherung
 
         #endregion
 
         #region ID commands for filler extended data
 
         #endregion
+
     }
 }

--- a/HBM.Weighing.API/WTX/Jet/JetBusException.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusException.cs
@@ -1,4 +1,34 @@
-﻿using Newtonsoft.Json.Linq;
+﻿// <copyright file="JetBusException.cs" company="Hottinger Baldwin Messtechnik GmbH">
+//
+// HBM.Weighing.API, a library to communicate with HBM weighing technology devices  
+//
+// The MIT License (MIT)
+//
+// Copyright (C) Hottinger Baldwin Messtechnik GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// </copyright>
+
+using Newtonsoft.Json.Linq;
 using System;
 
 

--- a/HBM.Weighing.API/WTX/WTXModbus.cs
+++ b/HBM.Weighing.API/WTX/WTXModbus.cs
@@ -336,8 +336,6 @@ namespace HBM.Weighing.API.WTX
             if (ProcessData.ApplicationModeStr == "Filler")           
                 DataFiller.UpdateFillerDataModbus(_data);
             
-            this.limitStatusBool();                                      // update the booleans 'Underload', 'Overload', 'weightWithinLimits', 'higherSafeLoadLimit'. 
-
             // Only if the net value changed, the data will be send to the GUI
             if(_previousNetValue != ProcessData.NetValue)
                 // Invoke Event - GUI/application class receives _processData: 
@@ -405,58 +403,18 @@ namespace HBM.Weighing.API.WTX
             }
         }
 
-
-        private void limitStatusBool()
-        {
-            switch (ProcessData.LimitStatus)
-            {
-                case 0: // Weight within limits
-                    ProcessData.Underload = false;
-                    ProcessData.Overload = false;
-                    ProcessData.weightWithinLimits = true;
-                    ProcessData.higherSafeLoadLimit = false;
-                    break;
-                case 1: // Lower than minimum
-                    ProcessData.Underload = true;
-                    ProcessData.Overload = false;
-                    ProcessData.weightWithinLimits = false;
-                    ProcessData.higherSafeLoadLimit = false;
-                    break;
-                case 2: // Higher than maximum capacity
-                    ProcessData.Underload = false;
-                    ProcessData.Overload = true;
-                    ProcessData.weightWithinLimits = false;
-                    ProcessData.higherSafeLoadLimit = false;
-                    break;
-                case 3: // Higher than safe load limit
-                    ProcessData.Underload = false;
-                    ProcessData.Overload = false;
-                    ProcessData.weightWithinLimits = false;
-                    ProcessData.higherSafeLoadLimit = true;
-                    break;
-                default: // Lower than minimum
-                    ProcessData.Underload = true;
-                    ProcessData.Overload = false;
-                    ProcessData.weightWithinLimits = false;
-                    ProcessData.higherSafeLoadLimit = false;
-                    break;
-            }
-        }
-
-        public string WeightTypeStringComment()
+        public override string WeightTypeStringComment()
         {
             if (ProcessData.WeightType == false)
             {
-                //this._isNet = false;
                 return "gross";
             }
-            else // if (this.WeightType == 1)
+            else
             {
-                //this._isNet = true;
                 return "net";
             }
         }
-        public string ScaleRangeStringComment()
+        public override string ScaleRangeStringComment()
         {
             switch (ProcessData.ScaleRange)
             {
@@ -470,13 +428,13 @@ namespace HBM.Weighing.API.WTX
                     return "error";
             }
         }
-        public string ApplicationModeStringComment()
+        public override string ApplicationModeStringComment()
         {
-            if (ProcessData.ApplicationMode == 0)
+            if (ProcessData.ApplicationMode == 0 || ProcessData.ApplicationMode == 1)
                 return "Standard";
             else
 
-                if (ProcessData.ApplicationMode == 2 || ProcessData.ApplicationMode == 1)  // Will be changed to '2', so far '1'. 
+                if (ProcessData.ApplicationMode == 2 || ProcessData.ApplicationMode == 3)
                 return "Filler";
             else
 
@@ -498,12 +456,12 @@ namespace HBM.Weighing.API.WTX
                     return "error";
             }
         }
-        public string StatusStringComment()
+        public override string StatusStringComment()
         {
-            if (ProcessData.Status == true)
+            if (ProcessData.Status == 1)
                 return "Execution OK!";
             else
-                if (ProcessData.Status != true)
+                if (ProcessData.Status != 1)
                 return "Execution not OK!";
             else
                 return "error.";


### PR DESCRIPTION
-Renaming and translation of command ID's for Jetbus in JetBusCommands.cs.  

-Adding comment methods to BaseWtDevice.cs for inheritance from WTXJet and WTXModbus. 

-Changing the datatype from boolean to integer of IProcessData-attribute 'status' (f.e. for Jetbus values for status = 1801...). 

-Putting method limitStatusBool() to class ProcessData for its immediate update. 

-Enabling data update of the filler attributes via Jetbus (with IMD-Input mode ID for standard/filler mode check). 

-Adding and renaming copyrights.