### PR TITLE
Integration of oberservern pattern to Data Classes ; Merge remote-Tracking branch 'upstream/master' - clean up and solved conflicts. 

### DIFF
--- a/HBM.Weighing.API/BaseWTDevice.cs
+++ b/HBM.Weighing.API/BaseWTDevice.cs
@@ -43,13 +43,15 @@ namespace HBM.Weighing.API
         /// Eventhandler to raise an event and commit the data to the GUI/application from WTXJet and WTXModbus
         public abstract event EventHandler<ProcessDataReceivedEventArgs> ProcessDataReceived;
 
+        public abstract event EventHandler<DataEventArgs> UpdateDataClasses;
+
         public abstract bool isConnected { get; }
         #endregion
 
         #region constructor of BaseWtDevice
         public BaseWtDevice(INetConnection connection) : base()
         {
-            _processData = new ProcessData();
+            _processData = new ProcessData(this);
 
             this._connection = connection;
         }

--- a/HBM.Weighing.API/Data/DataFillerExtended.cs
+++ b/HBM.Weighing.API/Data/DataFillerExtended.cs
@@ -129,14 +129,18 @@ namespace HBM.Weighing.API.Data
         private int _emptyWeightTolerance;
         private int _residualFlowDosingCycle;
 
-
+        private BaseWtDevice _baseWtDevice;
         #endregion
 
         #region constructor
 
-        public DataFillerExtended()
+        public DataFillerExtended(BaseWtDevice BaseWtDeviceObject):base(BaseWtDeviceObject)          
         {
-            _saveAllParameters=0;
+            _baseWtDevice = BaseWtDeviceObject;
+
+            _baseWtDevice.UpdateDataClasses += UpdateFillerExtendedDataJet;
+
+            _saveAllParameters =0;
             _restoreAllDefaultParameters=0;
             _vendorID=0;
             _productCode=0;
@@ -227,91 +231,92 @@ namespace HBM.Weighing.API.Data
 
         #region update method for the filler extended data
 
-        public void UpdateFillerExtendedDataJet(Dictionary<string, int> _data)
+        public void UpdateFillerExtendedDataJet(object sender, DataEventArgs e)
         {
-            this.UpdateFillerDataJet(_data);
+            if (_baseWtDevice.ProcessData.ApplicationMode == 2 || _baseWtDevice.ProcessData.ApplicationMode == 3)
+            {
+                this.UpdateFillerDataJet(this, e);
+                /*
+                _errorRegister = _data[JetBusCommands.ERROR_REGISTER];
+                _saveAllParameters = _data[JetBusCommands.SAVE_ALL_PARAMETERS];
+                _restoreAllDefaultParameters = _data[JetBusCommands.RESTORE_ALL_DEFAULT_PARAMETERS];
+                _vendorID = _data[JetBusCommands.VENDOR_ID];
 
-            /*
-            _errorRegister = _data[JetBusCommands.ERROR_REGISTER];
-            _saveAllParameters = _data[JetBusCommands.SAVE_ALL_PARAMETERS];
-            _restoreAllDefaultParameters = _data[JetBusCommands.RESTORE_ALL_DEFAULT_PARAMETERS];
-            _vendorID = _data[JetBusCommands.VENDOR_ID];
+                _productCode = _data[JetBusCommands.PRODUCT_CODE];
+                _serialNumber = _data[JetBusCommands.SERIAL_NUMBER];
+                _implementedProfileSpecification = _data[JetBusCommands.IMPLEMENTED_PROFILE_SPECIFICATION];
+                _lcCapability = _data[JetBusCommands.LC_CAPABILITY];
+                _weighingDevice1UnitPrefixOutputParameter = _data[JetBusCommands.WEIGHING_DEVICE_1_UNIT_PREFIX_OUTPUT_PARAMETER];
+                */
+                _weighingDevice1WeightStep = e.DataDictionary[JetBusCommands.WEIGHING_DEVICE_1_WEIGHT_STEP];
+                _alarms = e.DataDictionary[JetBusCommands.ALARMS];
+                _weighingDevice1OutputWeight = e.DataDictionary[JetBusCommands.WEIGHING_DEVICE_1_OUTPUT_WEIGHT];
+                _weighingDevice1Setting = e.DataDictionary[JetBusCommands.WEIGHING_DEVICE_1_SETTING];
 
-            _productCode = _data[JetBusCommands.PRODUCT_CODE];
-            _serialNumber = _data[JetBusCommands.SERIAL_NUMBER];
-            _implementedProfileSpecification = _data[JetBusCommands.IMPLEMENTED_PROFILE_SPECIFICATION];
-            _lcCapability = _data[JetBusCommands.LC_CAPABILITY];
-            _weighingDevice1UnitPrefixOutputParameter = _data[JetBusCommands.WEIGHING_DEVICE_1_UNIT_PREFIX_OUTPUT_PARAMETER];
-            */
-            _weighingDevice1WeightStep = _data[JetBusCommands.WEIGHING_DEVICE_1_WEIGHT_STEP];
-            _alarms = _data[JetBusCommands.ALARMS];
-            _weighingDevice1OutputWeight = _data[JetBusCommands.WEIGHING_DEVICE_1_OUTPUT_WEIGHT];
-            _weighingDevice1Setting = _data[JetBusCommands.WEIGHING_DEVICE_1_SETTING];
+                _localGravityFactor = e.DataDictionary[JetBusCommands.LOCAL_GRAVITY_FACTOR];
+                _scaleFilterSetup = e.DataDictionary[JetBusCommands.SCALE_FILTER_SETUP];
+                _dataSampleRate = e.DataDictionary[JetBusCommands.DATA_SAMPLE_RATE];
 
-            _localGravityFactor = _data[JetBusCommands.LOCAL_GRAVITY_FACTOR];
-            _scaleFilterSetup = _data[JetBusCommands.SCALE_FILTER_SETUP];
-            _dataSampleRate = _data[JetBusCommands.DATA_SAMPLE_RATE];
+                _filterOrderCriticallyDamped = e.DataDictionary[JetBusCommands.FILTER_ORDER_CRITICALLY_DAMPED];
+                _cutOffFrequencyCriticallyDamped = e.DataDictionary[JetBusCommands.CUT_OFF_FREQUENCY_CRITICALLY_DAMPED];
+                _filterOrderButterworth = e.DataDictionary[JetBusCommands.FILTER_ORDER_BUTTERWORTH];
+                _cutOffFrequencyButterWorth = e.DataDictionary[JetBusCommands.CUT_OFF_FREQUENCY_BUTTERWORTH];
+                _filterOrderBessel = e.DataDictionary[JetBusCommands.FILTER_ORDER_BESSEL];
 
-            _filterOrderCriticallyDamped = _data[JetBusCommands.FILTER_ORDER_CRITICALLY_DAMPED];
-            _cutOffFrequencyCriticallyDamped = _data[JetBusCommands.CUT_OFF_FREQUENCY_CRITICALLY_DAMPED];
-            _filterOrderButterworth = _data[JetBusCommands.FILTER_ORDER_BUTTERWORTH];
-            _cutOffFrequencyButterWorth = _data[JetBusCommands.CUT_OFF_FREQUENCY_BUTTERWORTH];
-            _filterOrderBessel = _data[JetBusCommands.FILTER_ORDER_BESSEL];
+                _cutOffFrequencyBessel = e.DataDictionary[JetBusCommands.CUT_OFF_FREQUENCY_BESSEL];
+                _scaleSupplyNominalVoltage = e.DataDictionary[JetBusCommands.SCALE_SUPPY_NOMINAL_VOLTAGE];
+                _scaleSupplyMinimumVoltage = e.DataDictionary[JetBusCommands.SCALE_SUPPY_MINIMUM_VOLTAGE];
+                _scaleSupplyMaximumVoltage = e.DataDictionary[JetBusCommands.SCALE_SUPPY_MAXIMUM_VOLTAGE];
 
-            _cutOffFrequencyBessel = _data[JetBusCommands.CUT_OFF_FREQUENCY_BESSEL];
-            _scaleSupplyNominalVoltage = _data[JetBusCommands.SCALE_SUPPY_NOMINAL_VOLTAGE];
-            _scaleSupplyMinimumVoltage = _data[JetBusCommands.SCALE_SUPPY_MINIMUM_VOLTAGE];
-            _scaleSupplyMaximumVoltage = _data[JetBusCommands.SCALE_SUPPY_MAXIMUM_VOLTAGE];
+                _scaleAccuracyClass = e.DataDictionary[JetBusCommands.SCALE_ACCURACY_CLASS];
+                _scaleMinimumDeadLoad = e.DataDictionary[JetBusCommands.SCALE_MINIMUM_DEAD_LOAD];
+                _scaleMaximumCapacity = e.DataDictionary[JetBusCommands.SCALE_MAXIMUM_CAPACITY];
+                _scaleMaximumNumberVerificationInterval = e.DataDictionary[JetBusCommands.SCALE_MAXIMUM_NUMBER_OF_VERIFICATION_INTERVAL];
+                _scaleApportionmentFactor = e.DataDictionary[JetBusCommands.SCALE_APPORTIONMENT_FACTOR];
+                _scaleSafeLoadLimit = e.DataDictionary[JetBusCommands.SCALE_SAFE_LOAD_LIMIT];
+                _scaleOperationNominalTemperature = e.DataDictionary[JetBusCommands.SCALE_OPERATION_NOMINAL_TEMPERATURE];
+                _scaleOperationMinimumTemperature = e.DataDictionary[JetBusCommands.SCALE_OPERATION_MINIMUM_TEMPERATURE];
+                _scaleOperationMaximumTemperature = e.DataDictionary[JetBusCommands.SCALE_OPERATION_MAXIMUM_TEMPERATURE];
 
-            _scaleAccuracyClass = _data[JetBusCommands.SCALE_ACCURACY_CLASS];
-            _scaleMinimumDeadLoad = _data[JetBusCommands.SCALE_MINIMUM_DEAD_LOAD];
-            _scaleMaximumCapacity = _data[JetBusCommands.SCALE_MAXIMUM_CAPACITY];
-            _scaleMaximumNumberVerificationInterval = _data[JetBusCommands.SCALE_MAXIMUM_NUMBER_OF_VERIFICATION_INTERVAL];
-            _scaleApportionmentFactor = _data[JetBusCommands.SCALE_APPORTIONMENT_FACTOR];
-            _scaleSafeLoadLimit = _data[JetBusCommands.SCALE_SAFE_LOAD_LIMIT];
-            _scaleOperationNominalTemperature = _data[JetBusCommands.SCALE_OPERATION_NOMINAL_TEMPERATURE];
-            _scaleOperationMinimumTemperature = _data[JetBusCommands.SCALE_OPERATION_MINIMUM_TEMPERATURE];
-            _scaleOperationMaximumTemperature = _data[JetBusCommands.SCALE_OPERATION_MAXIMUM_TEMPERATURE];
+                //_scaleRelativeMinimumLoadCellVerficationInterval = e.DataDictionary[JetBusCommands.SCALE_RELATIVE_MINIMUM_LOAD_CELL_VERIFICATION_INTERVAL];
+                _intervalRangeControl = e.DataDictionary[JetBusCommands.INTERVAL_RANGE_CONTROL];
+                _multiLimit1 = e.DataDictionary[JetBusCommands.MULTI_LIMIT_1];
+                _multiLimit2 = e.DataDictionary[JetBusCommands.MULTI_LIMIT_2];
+                //_oimlCertificationInformation = e.DataDictionary[JetBusCommands.OIML_CERTIFICAITON_INFORMATION];
+                //_ntepCertificationInformation = e.DataDictionary[JetBusCommands.NTEP_CERTIFICAITON_INFORMATION];
+                _maximumZeroingTime = e.DataDictionary[JetBusCommands.MAXIMUM_ZEROING_TIME];
+                _maximumPeakValueGross = e.DataDictionary[JetBusCommands.MAXIMUM_PEAK_VALUE_GROSS];
+                _minimumPeakValueGross = e.DataDictionary[JetBusCommands.MINIMUM_PEAK_VALUE_GROSS];
 
-            //_scaleRelativeMinimumLoadCellVerficationInterval = _data[JetBusCommands.SCALE_RELATIVE_MINIMUM_LOAD_CELL_VERIFICATION_INTERVAL];
-            _intervalRangeControl = _data[JetBusCommands.INTERVAL_RANGE_CONTROL];
-            _multiLimit1 = _data[JetBusCommands.MULTI_LIMIT_1];
-            _multiLimit2 = _data[JetBusCommands.MULTI_LIMIT_2];
-            //_oimlCertificationInformation = _data[JetBusCommands.OIML_CERTIFICAITON_INFORMATION];
-            //_ntepCertificationInformation = _data[JetBusCommands.NTEP_CERTIFICAITON_INFORMATION];
-            _maximumZeroingTime = _data[JetBusCommands.MAXIMUM_ZEROING_TIME];
-            _maximumPeakValueGross = _data[JetBusCommands.MAXIMUM_PEAK_VALUE_GROSS];
-            _minimumPeakValueGross = _data[JetBusCommands.MINIMUM_PEAK_VALUE_GROSS];
+                _maximumPeakValue = e.DataDictionary[JetBusCommands.MAXIMUM_PEAK_VALUE];
+                _minimumPeakValue = e.DataDictionary[JetBusCommands.MINIMUM_PEAK_VALUE];
+                _weightMovingDetection = e.DataDictionary[JetBusCommands.WEIGHT_MOVING_DETECTION];
+                //_deviceAddress = e.DataDictionary[JetBusCommands.DEVICE_ADDRESS];
+                //_hardwareVersion = e.DataDictionary[JetBusCommands.HAREWARE_VERSION];
+                //_identification = e.DataDictionary[JetBusCommands.IDENTIFICATION];
 
-            _maximumPeakValue = _data[JetBusCommands.MAXIMUM_PEAK_VALUE];
-            _minimumPeakValue = _data[JetBusCommands.MINIMUM_PEAK_VALUE];
-            _weightMovingDetection = _data[JetBusCommands.WEIGHT_MOVING_DETECTION];
-            //_deviceAddress = _data[JetBusCommands.DEVICE_ADDRESS];
-            //_hardwareVersion = _data[JetBusCommands.HAREWARE_VERSION];
-            //_identification = _data[JetBusCommands.IDENTIFICATION];
+                _outputScale = e.DataDictionary[JetBusCommands.OUTPUT_SCALE];
+                //_firmwareDate = e.DataDictionary[JetBusCommands.FIRMWARE_DATE];
+                _resetTrigger = e.DataDictionary[JetBusCommands.RESET_TRIGGER];
+                _stateDigital_IO_Extended = e.DataDictionary[JetBusCommands.STATE_DIGITAL_IO_EXTENDED];
 
-            _outputScale = _data[JetBusCommands.OUTPUT_SCALE];
-            //_firmwareDate = _data[JetBusCommands.FIRMWARE_DATE];
-            _resetTrigger = _data[JetBusCommands.RESET_TRIGGER];
-            _stateDigital_IO_Extended = _data[JetBusCommands.STATE_DIGITAL_IO_EXTENDED];
+                //_softwareIdentification = e.DataDictionary[JetBusCommands.SOFTWARE_IDENTIFICATION];
+                //_softwareVersion = e.DataDictionary[JetBusCommands.SOFTWARE_VERSION];
+                _dateTime = e.DataDictionary[JetBusCommands.DATE_TIME];
 
-            //_softwareIdentification = _data[JetBusCommands.SOFTWARE_IDENTIFICATION];
-            //_softwareVersion = _data[JetBusCommands.SOFTWARE_VERSION];
-            _dateTime = _data[JetBusCommands.DATE_TIME];
+                _breakDosing = e.DataDictionary[JetBusCommands.BREAK_DOSING];
+                _deleteDosingResult = e.DataDictionary[JetBusCommands.DELETE_DOSING_RESULT];
+                _materialStreamLastDosing = e.DataDictionary[JetBusCommands.MATERIAL_STREAM_LAST_DOSING];
+                _sum = e.DataDictionary[JetBusCommands.SUM];
+                _specialDosingFunctions = e.DataDictionary[JetBusCommands.SPECIAL_DOSING_FUNCTIONS];
+                _dischargeTime = e.DataDictionary[JetBusCommands.DISCHARGE_TIME];
+                _exceedingWeightBreak = e.DataDictionary[JetBusCommands.EXCEEDING_WEIGHT_BREAK];
+                _delay1Dosing = e.DataDictionary[JetBusCommands.DELAY1_DOSING];
+                _delay2Dosing = e.DataDictionary[JetBusCommands.DELAY2_DOSING];
+                _emptyWeightTolerance = e.DataDictionary[JetBusCommands.EMPTY_WEIGHT_TOLERANCE];
+                _residualFlowDosingCycle = e.DataDictionary[JetBusCommands.RESIDUAL_FLOW_DOSING_CYCLE];
 
-            _breakDosing = _data[JetBusCommands.BREAK_DOSING];
-            _deleteDosingResult = _data[JetBusCommands.DELETE_DOSING_RESULT];
-            _materialStreamLastDosing = _data[JetBusCommands.MATERIAL_STREAM_LAST_DOSING];
-            _sum = _data[JetBusCommands.SUM];
-            _specialDosingFunctions = _data[JetBusCommands.SPECIAL_DOSING_FUNCTIONS];
-            _dischargeTime = _data[JetBusCommands.DISCHARGE_TIME];
-            _exceedingWeightBreak = _data[JetBusCommands.EXCEEDING_WEIGHT_BREAK];
-            _delay1Dosing = _data[JetBusCommands.DELAY1_DOSING];
-            _delay2Dosing = _data[JetBusCommands.DELAY2_DOSING];
-            _emptyWeightTolerance = _data[JetBusCommands.EMPTY_WEIGHT_TOLERANCE];
-            _residualFlowDosingCycle = _data[JetBusCommands.RESIDUAL_FLOW_DOSING_CYCLE];
-
-
+            }
         }
 
         #endregion

--- a/HBM.Weighing.API/Data/IDataFiller.cs
+++ b/HBM.Weighing.API/Data/IDataFiller.cs
@@ -127,8 +127,8 @@ namespace HBM.Weighing.API
 
         #region Update methods for the data of standard mode
 
-        void UpdateFillerDataModbus(ushort[] _dataParam);
-        void UpdateFillerDataJet(Dictionary<string, int> _dataParam);
+        void UpdateFillerDataModbus(object sender, DataEventArgs e);
+        void UpdateFillerDataJet(object sender, DataEventArgs e);
 
         #endregion
     }

--- a/HBM.Weighing.API/Data/IDataFillerExtended.cs
+++ b/HBM.Weighing.API/Data/IDataFillerExtended.cs
@@ -135,7 +135,7 @@ namespace HBM.Weighing.API
 
         #region Update methods for the data of filler extended mode
         
-        void UpdateFillerExtendedDataJet(Dictionary<string, int> _dataParam);
+        void UpdateFillerExtendedDataJet(object sender, DataEventArgs e);
 
         #endregion
     }

--- a/HBM.Weighing.API/Data/IDataStandard.cs
+++ b/HBM.Weighing.API/Data/IDataStandard.cs
@@ -99,8 +99,8 @@ namespace HBM.Weighing.API
 
         #region Update methods for the data of standard mode
 
-        void UpdateStandardDataModbus(ushort[] _dataParam);
-        void UpdateStandardDataJet(Dictionary<string, int> _dataParam);
+        void UpdateStandardDataModbus(object sender, DataEventArgs e);
+        void UpdateStandardDataJet(object sender, DataEventArgs e);
 
         #endregion
     }

--- a/HBM.Weighing.API/Data/IProcessData.cs
+++ b/HBM.Weighing.API/Data/IProcessData.cs
@@ -77,8 +77,9 @@ namespace HBM.Weighing.API
 
         #region Update methods for the process data
 
-        void UpdateProcessDataModbus(ushort[] _dataParam);
-        void UpdateProcessDataJet(Dictionary<string, int> _dataParam);
+        void UpdateProcessDataModbus(object sender, DataEventArgs e);
+        void UpdateProcessDataJet(object sender, DataEventArgs e);
+
 
         #endregion
     }

--- a/HBM.Weighing.API/DataEventArgs.cs
+++ b/HBM.Weighing.API/DataEventArgs.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HBM.Weighing.API
+{
+    public class DataEventArgs
+    {
+        private ushort[] _dataArray;
+        private Dictionary<string, int> _dataDict;
+
+        public DataEventArgs(ushort[] _dataArrayParam, Dictionary<string,int> _dataDictParam)
+        {
+            this._dataArray = _dataArrayParam;
+            this._dataDict = _dataDictParam; 
+        }
+
+        public ushort[] Data
+        {
+            get
+            {
+                return this._dataArray;
+            }
+            set
+            {
+                this._dataArray = value;
+            }
+        }
+
+        public Dictionary<string,int> DataDictionary
+        {
+            get
+            {
+                return this._dataDict;
+            }
+            set
+            {
+                this._dataDict = value;
+            }
+        }
+    }
+}
+

--- a/HBM.Weighing.API/HBM.Weighing.API.csproj
+++ b/HBM.Weighing.API/HBM.Weighing.API.csproj
@@ -62,6 +62,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataEventArgs.cs" />
     <Compile Include="Data\DataFiller.cs" />
     <Compile Include="Data\DataFillerExtended.cs" />
     <Compile Include="Data\DataStandard.cs" />

--- a/HBM.Weighing.API/INetConnection.cs
+++ b/HBM.Weighing.API/INetConnection.cs
@@ -40,7 +40,7 @@ namespace HBM.Weighing.API
     {
         event EventHandler BusActivityDetection;
 
-        event EventHandler<ProcessDataReceivedEventArgs> IncomingDataReceived;
+        event EventHandler<DataEventArgs> IncomingDataReceived;
 
         string IpAddress    { get; set; }       
 

--- a/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
@@ -57,7 +57,7 @@ namespace HBM.Weighing.API.WTX.Jet
         private Exception _mException = null;
 
         public event EventHandler BusActivityDetection;
-        public event EventHandler<ProcessDataReceivedEventArgs> IncomingDataReceived;
+        public event EventHandler<DataEventArgs> IncomingDataReceived;
 
         private bool _connected;
 
@@ -209,7 +209,7 @@ namespace HBM.Weighing.API.WTX.Jet
 
             dataArrived = true;
             
-            IncomingDataReceived?.Invoke(this, null);  // For getting data already in the FetchAll() 
+            IncomingDataReceived?.Invoke(this, new DataEventArgs(this.DataUshortArray, this._dataIntegerBuffer));  // For getting data already in the FetchAll() 
         }
 
         protected virtual void WaitOne(int timeoutMultiplier = 1)
@@ -281,7 +281,7 @@ namespace HBM.Weighing.API.WTX.Jet
                 this.ConvertJTokenToStringArray();
               
                 if (dataArrived == true)
-                    IncomingDataReceived?.Invoke(this, null);
+                    IncomingDataReceived?.Invoke(this, new DataEventArgs(this.DataUshortArray, this._dataIntegerBuffer));
 
                 BusActivityDetection?.Invoke(this, new LogEvent(data.ToString()));
             }

--- a/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
@@ -112,7 +112,7 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         public event EventHandler BusActivityDetection;
 
-        public virtual event EventHandler<ProcessDataReceivedEventArgs> IncomingDataReceived; // virtual new due to tesing - 3.5.2018
+        public virtual event EventHandler<DataEventArgs> IncomingDataReceived; // virtual new due to tesing - 3.5.2018
 
         /// <summary>
         /// This method is called from the device class "WTX120" to read the register of the device. 

--- a/HBM.Weighing.API/WTX/WTXJet.cs
+++ b/HBM.Weighing.API/WTX/WTXJet.cs
@@ -61,6 +61,7 @@ namespace HBM.Weighing.API.WTX
 
         #region Events
         public override event EventHandler<ProcessDataReceivedEventArgs> ProcessDataReceived;
+        public override event EventHandler<DataEventArgs> UpdateDataClasses;
         #endregion
 
         #region Constructors
@@ -72,8 +73,8 @@ namespace HBM.Weighing.API.WTX
 
             _connection.IncomingDataReceived += this.OnData;   // Subscribe to the event.   
 
-            DataStandard = new DataStandard();
-            DataFillerExtended = new DataFillerExtended();
+            DataStandard = new DataStandard(this);
+            DataFillerExtended = new DataFillerExtended(this);
         }
         #endregion
 
@@ -112,22 +113,10 @@ namespace HBM.Weighing.API.WTX
         #endregion
 
         #region Asynchronous process data callback
-        public void OnData(object sender, ProcessDataReceivedEventArgs e)
+        public void OnData(object sender, DataEventArgs e)
         {
-            // Update data for standard mode:
-            if (ProcessData.ApplicationMode == 0 || ProcessData.ApplicationMode == 1)
-            {
-                DataStandard.UpdateStandardDataJet(_connection.AllData);
-            }
-            // Update process data : 
-            ProcessData.UpdateProcessDataJet(_connection.AllData);
-
-            // Update data for filler mode:
-            if (ProcessData.ApplicationMode == 2 || ProcessData.ApplicationMode == 3)
-            {
-                // Update data for filler extended mode:
-                DataFillerExtended.UpdateFillerExtendedDataJet(_connection.AllData);
-            }
+            if(e!=null)
+                this.UpdateDataClasses?.Invoke(this, new DataEventArgs(e.Data, e.DataDictionary));
 
             // Do something with the data, like in the class WTXModbus.cs           
             this.ProcessDataReceived?.Invoke(this, new ProcessDataReceivedEventArgs(ProcessData));

--- a/Tests/JetbusTest/TestJetbusConnection.cs
+++ b/Tests/JetbusTest/TestJetbusConnection.cs
@@ -108,7 +108,7 @@ namespace HBM.Weighing.API.WTX.Jet
         private bool connected;
 
         public event EventHandler BusActivityDetection;
-        public event EventHandler<ProcessDataReceivedEventArgs> IncomingDataReceived;
+        public event EventHandler<DataEventArgs> IncomingDataReceived;
 
         private int _mTimeoutMs;
 
@@ -232,7 +232,7 @@ namespace HBM.Weighing.API.WTX.Jet
             this.ConvertJTokenToStringArray();
 
             if (this.behavior != Behavior.ReadFail_DataReceived)
-                IncomingDataReceived?.Invoke(this, new ProcessDataReceivedEventArgs(new ProcessData()));
+                IncomingDataReceived?.Invoke(this, null /*new ProcessDataReceivedEventArgs(new ProcessData())*/);
 
             return _dataBuffer[index.ToString()];
             

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -171,7 +171,7 @@ namespace HBM.Weighing.API.WTX.Modbus
         public int command; 
 
         public event EventHandler BusActivityDetection;
-        public event EventHandler<ProcessDataReceivedEventArgs> IncomingDataReceived;
+        public event EventHandler<DataEventArgs> IncomingDataReceived;
 
         private string IP;
         private int interval;
@@ -378,7 +378,7 @@ namespace HBM.Weighing.API.WTX.Modbus
                     break;
             }
 
-            IncomingDataReceived?.Invoke(this, new ProcessDataReceivedEventArgs(new ProcessData()));
+            IncomingDataReceived?.Invoke(this, null/*new ProcessDataReceivedEventArgs(new ProcessData())*/);
 
             return _dataWTX[Convert.ToInt16(index)];
         }


### PR DESCRIPTION
-Integration of observer pattern to Data : Eventbased call from WTXModbus, WTXJet to data classes - Therefore a new event "DataEventArgs" having ushort[] and Dictionary<string,int>.

-Merge remote-tracking branch 'upstream/master' - Clean up and solved conflicts referring to the previous commit.

# Conflicts:
#	HBM.Weighing.API/Data/ProcessData.cs
#	HBM.Weighing.API/WTX/WTXJet.cs
#	HBM.Weighing.API/WTX/WTXModbus.cs