### PR TITLE
-Enabling to read from index/command 'limit value status' (bit masking&shifting with brackets!). Using method the 'index(IDCommand)' with '.Split(deletedString)'.

### DIFF
--- a/HBM.Weighing.API/Data/DataFiller.cs
+++ b/HBM.Weighing.API/Data/DataFiller.cs
@@ -273,22 +273,6 @@ namespace HBM.Weighing.API.Data
 
         #endregion
 
-
-        private string getIndex(string indexParam)
-        {
-            if (indexParam.Contains("filler"))
-            {
-                if (indexParam.Length == 15)
-                    _index = indexParam.Remove(1);
-                if (indexParam.Length == 16)
-                    _index = indexParam.Remove(2);
-            }
-            else
-                _index = indexParam;
-
-            return _index;
-        }
-
         #region Get-properties for input words of filler mode
 
         public int CoarseFlow
@@ -429,121 +413,122 @@ namespace HBM.Weighing.API.Data
         public int ResidualFlowTime // Type : unsigned integer 16 Bit
         {
             get { return _residualFlowTime; }
-            set { _connection.Write(_connection.IDCommands.RESIDUAL_FLOW_TIME, value);
+            set {
+                  _connection.Write(this.getIndex(_connection.IDCommands.RESIDUAL_FLOW_TIME), value);
                   this._residualFlowTime = value; }
         }
         public int TargetFillingWeight // Type : signed integer 32 Bit
         {
             get { return _targetFillingWeight; }
-            set { _connection.Write(_connection.IDCommands.REFERENCE_VALUE_DOSING, value);
-                   this._targetFillingWeight = value; }
+            set { _connection.Write(this.getIndex(_connection.IDCommands.REFERENCE_VALUE_DOSING), value);
+                this._targetFillingWeight = value; }
         }
         public int CoarseFlowCutOffPointSet // Type : signed integer 32 Bit
         {
             get { return _coarseFlowCutOffPointSet; }
-            set { _connection.Write(_connection.IDCommands.COARSE_FLOW_CUT_OFF_POINT, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.COARSE_FLOW_CUT_OFF_POINT), value);
                 this._coarseFlowCutOffPointSet = value; }
         }
         public int FineFlowCutOffPointSet // Type : signed integer 32 Bit
         {
             get { return _fineFlowCutOffPointSet; }
-            set { _connection.Write(_connection.IDCommands.FINE_FLOW_CUT_OFF_POINT, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.FINE_FLOW_CUT_OFF_POINT), value);
                 this._fineFlowCutOffPointSet = value; }
         }
         public int MinimumFineFlow // Type : signed integer 32 Bit
         {
             get { return _minimumFineFlow; }
-            set { _connection.Write(_connection.IDCommands.MINIMUM_FINE_FLOW, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.MINIMUM_FINE_FLOW), value);
                 this._minimumFineFlow = value; }
         }
         public int OptimizationOfCutOffPoints // Type : unsigned integer 8 Bit
         {
             get { return _optimizationOfCutOffPoints; }
-            set { _connection.Write(_connection.IDCommands.OPTIMIZATION, value);
-                  this._optimizationOfCutOffPoints = value; }
+            set { _connection.Write(this.getIndex(_connection.IDCommands.OPTIMIZATION), value);
+                this._optimizationOfCutOffPoints = value; }
         }
         public int MaximumDosingTime // Type : unsigned integer 16 Bit
         {
             get { return _maximumDosingTime; }
-            set { _connection.Write(_connection.IDCommands.MAXIMAL_DOSING_TIME, value);
-                  this._maximumDosingTime = value; }
+            set { _connection.Write(this.getIndex(_connection.IDCommands.MAXIMAL_DOSING_TIME), value);
+                this._maximumDosingTime = value; }
         }
         public int StartWithFineFlow // Type : unsigned integer 16 Bit
         {
             get { return _startWithFineFlow; }
-            set { _connection.Write(_connection.IDCommands.RUN_START_DOSING, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.RUN_START_DOSING), value);
                 this._startWithFineFlow = value; }
         }
         public int CoarseLockoutTime // Type : unsigned integer 16 Bit
         {
             get { return _coarseLockoutTime; }
-            set { _connection.Write(_connection.IDCommands.LOCKOUT_TIME_COARSE_FLOW, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.LOCKOUT_TIME_COARSE_FLOW), value);
                 this._coarseLockoutTime = value; }
         }
         public int FineLockoutTime // Type : unsigned integer 16 Bit
         {
             get { return _fineLockoutTime; }
-            set { _connection.Write(_connection.IDCommands.LOCKOUT_TIME_FINE_FLOW, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.LOCKOUT_TIME_FINE_FLOW), value);
                 this._fineLockoutTime = value; }
         }
         public int TareMode // Type : unsigned integer 8 Bit
         {
             get { return _tareMode; }
-            set { _connection.Write(_connection.IDCommands.TARE_MODE, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.TARE_MODE), value);
                 this._tareMode = value; }
         }
         public int UpperToleranceLimit // Type : signed integer 32 Bit
         {
             get { return _upperToleranceLimit; }
-            set { _connection.Write(_connection.IDCommands.UPPER_TOLERANCE_LIMIT, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.UPPER_TOLERANCE_LIMIT), value);
                 this._upperToleranceLimit = value; }
         }
         public int LowerToleranceLimit // Type : signed integer 32 Bit
         {
             get { return _lowerToleranceLimit; }
-            set { _connection.Write(_connection.IDCommands.LOWER_TOLERANCE_LIMIT, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.LOWER_TOLERANCE_LIMIT), value);
                 this._lowerToleranceLimit = value; }
         }
         public int MinimumStartWeight // Type : signed integer 32 Bit
         {
             get { return _minimumStartWeight; }
-            set { _connection.Write(_connection.IDCommands.MINIMUM_START_WEIGHT, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.MINIMUM_START_WEIGHT), value);
                 this._minimumStartWeight = value; }
         }
         public int EmptyWeight // Type : signed integer 32 Bit
         {
             get { return _emptyWeight; }
-            set { _connection.Write(_connection.IDCommands.EMPTY_WEIGHT_TOLERANCE, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.EMPTY_WEIGHT_TOLERANCE), value);
                 this._emptyWeight = value; }
         }
         public int TareDelay // Type : unsigned integer 16 Bit
         {
             get { return _tareDelay; }
-            set { _connection.Write(_connection.IDCommands.TARE_DELAY, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.TARE_DELAY), value);
                 this._tareDelay = value; }
         }
         public int CoarseFlowMonitoringTime // Type : unsigned integer 16 Bit
         {
             get { return _coarseFlowMonitoringTime; }
-            set { _connection.Write(_connection.IDCommands.COARSE_FLOW_MONITORING_TIME, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.COARSE_FLOW_MONITORING_TIME), value);
                 this._coarseFlowMonitoringTime = value; }
         }
         public int CoarseFlowMonitoring  // Type : unsigned integer 32 Bit
         {
             get { return _coarseFlowMonitoring; }
-            set { _connection.Write(_connection.IDCommands.COARSE_FLOW_MONITORING, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.COARSE_FLOW_MONITORING), value);
                 this._coarseFlowMonitoring = value; }
         }
         public int FineFlowMonitoring  // Type : unsigned integer 32 Bit
         {
             get { return _fineFlowMonitoring; }
-            set { _connection.Write(_connection.IDCommands.FINE_FLOW_MONITORING, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.FINE_FLOW_MONITORING), value);
                 this._fineFlowMonitoring = value; }
         }
         public int FineFlowMonitoringTime // Type : unsigned integer 16 Bit
         {
             get { return _fineFlowMonitoringTime; }
-            set { _connection.Write(_connection.IDCommands.FINE_FLOW_MONITORING_TIME, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.FINE_FLOW_MONITORING_TIME), value);
                 this._fineFlowMonitoringTime = value; }
         }
         public int DelayTimeAfterFineFlow  // Type : unsigned integer 8 Bit
@@ -561,7 +546,7 @@ namespace HBM.Weighing.API.Data
         public int SystematicDifference // Type : unsigned integer 32 Bit
         {
             get { return _systematicDifference; }
-            set { _connection.Write(_connection.IDCommands.SYSTEMATIC_DIFFERENCE, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.SYSTEMATIC_DIFFERENCE), value);
                 this._systematicDifference = value; }
         }
         public int DownwardsDosing  // Type : unsigned integer 8 Bit
@@ -573,15 +558,20 @@ namespace HBM.Weighing.API.Data
         public int ValveControl  // Type : unsigned integer 8 Bit
         {
             get { return _valveControl; }
-            set { _connection.Write(_connection.IDCommands.VALVE_CONTROL, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.VALVE_CONTROL), value);
                 this._valveControl = value; }
         }
     
         public int EmptyingMode  // Type : unsigned integer 8 Bit
         {
             get { return _emptyingMode; }
-            set { _connection.Write(_connection.IDCommands.EMPTYING_MODE, value);
+            set { _connection.Write(this.getIndex(_connection.IDCommands.EMPTYING_MODE), value);
                 this._emptyingMode = value; }
+        }
+
+        private string getIndex(string IDCommandParam)
+        {
+            return IDCommandParam.Split('\\')[0];
         }
         #endregion
 

--- a/HBM.Weighing.API/Data/DataStandard.cs
+++ b/HBM.Weighing.API/Data/DataStandard.cs
@@ -240,6 +240,7 @@ namespace HBM.Weighing.API.Data
                 _switchOnLevelLIV13 = e.DataDictionary[_connection.IDCommands.SWITCH_ON_LEVEL_LIV13];
                 _switchOffLevelLIV14 = e.DataDictionary[_connection.IDCommands.SWITCH_OFF_LEVEL_LIV14];
 
+                /*
                 _limitValueMonitoringLIV21 = e.DataDictionary[_connection.IDCommands.LIMIT_VALUE_MONITORING_LIV21];
                 _signalSourceLIV22 = e.DataDictionary[_connection.IDCommands.SIGNAL_SOURCE_LIV22];
                 _switchOnLevelLIV23 = e.DataDictionary[_connection.IDCommands.SWITCH_ON_LEVEL_LIV23];
@@ -254,6 +255,7 @@ namespace HBM.Weighing.API.Data
                 _signalSourceLIV42 = e.DataDictionary[_connection.IDCommands.SIGNAL_SOURCE_LIV42];
                 _switchOnLevelLIV43 = e.DataDictionary[_connection.IDCommands.SWITCH_ON_LEVEL_LIV43];
                 _switchOffLevelLIV44 = e.DataDictionary[_connection.IDCommands.SWITCH_OFF_LEVEL_LIV44];
+                */
             }
                 
         }

--- a/HBM.Weighing.API/Data/DataStandard.cs
+++ b/HBM.Weighing.API/Data/DataStandard.cs
@@ -204,7 +204,7 @@ namespace HBM.Weighing.API.Data
         public void UpdateStandardData(object sender, DataEventArgs e)
         {
             
-            if (_connection.IDCommands.STATUS_DIGITAL_INPUT_1 == "6/1") _input1 = e.DataDictionary[_connection.IDCommands.STATUS_DIGITAL_INPUT_1] & 0x1;
+            if (_connection.IDCommands.STATUS_DIGITAL_INPUT_1 == "6/1") _input1 = (e.DataDictionary[_connection.IDCommands.STATUS_DIGITAL_INPUT_1] & 0x1);
             else _input1 = e.DataDictionary[_connection.IDCommands.STATUS_DIGITAL_INPUT_1];
 
             if (_connection.IDCommands.STATUS_DIGITAL_INPUT_1 == "6/2") _input2 = (e.DataDictionary[_connection.IDCommands.STATUS_DIGITAL_INPUT_2] & 0x2) >> 1;
@@ -228,10 +228,10 @@ namespace HBM.Weighing.API.Data
             if (_connection.IDCommands.STATUS_DIGITAL_INPUT_1 == "7/4") _output4 = (e.DataDictionary[_connection.IDCommands.STATUS_DIGITAL_OUTPUT_4] & 0x8) >> 3;
             else _output4 = e.DataDictionary[_connection.IDCommands.STATUS_DIGITAL_OUTPUT_4];
             
-            _limitStatus1 = e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x1;
-            _limitStatus2 = e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x2 >> 1;
-            _limitStatus3 = e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x4 >> 2;
-            _limitStatus4 = e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x8 >> 3;
+            _limitStatus1 = (e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x1);
+            _limitStatus2 = (e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x2) >> 1;
+            _limitStatus3 = (e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x4) >> 2;
+            _limitStatus4 = (e.DataDictionary[_connection.IDCommands.LIMIT_VALUE] & 0x8) >> 3;
 
             if (e.DataDictionary[_connection.IDCommands.APPLICATION_MODE] == 0)
             {
@@ -537,23 +537,12 @@ namespace HBM.Weighing.API.Data
         }
 
         #endregion
-
-        private string getIndex(string indexParam)
+        
+        private string getIndex(string IDCommandParam)
         {
-            if (indexParam.Contains("standard"))
-            {
-                if (indexParam.Length == 16)
-                    _index = indexParam.Remove(1);
-                if (indexParam.Length == 17)
-                    _index = indexParam.Remove(1);
-                if (indexParam.Length == 18)
-                    _index = indexParam.Remove(2);
-            }
-            else
-                _index = indexParam;
-
-            return _index;
+            return IDCommandParam.Split('/')[0];
         }
+       
 
     }
 }

--- a/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
@@ -313,6 +313,7 @@ namespace HBM.Weighing.API.WTX.Modbus
             _dataIntegerBuffer.Add(IDCommands.STATUS_DIGITAL_OUTPUT_4, 0);
 
             _dataIntegerBuffer.Add(IDCommands.LIMIT_VALUE, 0);
+
             _dataIntegerBuffer.Add(IDCommands.LIMIT_VALUE_MONITORING_LIV11, 0); ;
             _dataIntegerBuffer.Add(IDCommands.SIGNAL_SOURCE_LIV12, 0);
             _dataIntegerBuffer.Add(IDCommands.SWITCH_ON_LEVEL_LIV13, 0);
@@ -371,6 +372,7 @@ namespace HBM.Weighing.API.WTX.Modbus
                 _dataIntegerBuffer[IDCommands.FINE_FLOW_TIME] = _data[26];              // _currentFineFlowTime
                 _dataIntegerBuffer[IDCommands.RANGE_SELECTION_PARAMETER] = _data[27];   // _parameterSetProduct
 
+                _dataIntegerBuffer[IDCommands.LIMIT_VALUE] = _data[8];
 
             // Standard data: Missing ID's
             /*

--- a/Tests/ModbusTest/ReadTestsModbus.cs
+++ b/Tests/ModbusTest/ReadTestsModbus.cs
@@ -35,7 +35,7 @@ namespace HBM.Weighing.API.WTX.Modbus
             get
             {
                 yield return new TestCaseData(Behavior.ReadFail).Returns(0);
-                yield return new TestCaseData(Behavior.ReadSuccess).Returns(16448);
+                yield return new TestCaseData(Behavior.ReadSuccess).Returns(3);
 
                 //Alternatives: 
 
@@ -105,27 +105,9 @@ namespace HBM.Weighing.API.WTX.Modbus
                 _dataReadSuccess[i] = 0;
                 _dataReadFail[i] = 0;
             }
-
-            _dataReadSuccess[0] = 16448;       // Net value
-            _dataReadSuccess[1] = 16448;       // Gross value
-            _dataReadSuccess[2] = 0;           // General weight error
-            _dataReadSuccess[3] = 0;           // Scale alarm triggered
-            _dataReadSuccess[4] = 0;           // Limit status
-            _dataReadSuccess[5] = 0;           // Weight moving
-            _dataReadSuccess[6] = 0;//1;       // Scale seal is open
-            _dataReadSuccess[7] = 0;           // Manual tare
-            _dataReadSuccess[8] = 0;           // Weight type
-            _dataReadSuccess[9] = 0;           // Scale range
-            _dataReadSuccess[10] = 0;          // Zero required/True zero
-            _dataReadSuccess[11] = 0;          // Weight within center of zero 
-            _dataReadSuccess[12] = 0;          // weight in zero range
-            _dataReadSuccess[13] = 0;          // Application mode = 0
-            _dataReadSuccess[14] = 0; //4;     // Decimal Places
-            _dataReadSuccess[15] = 0; //2;     // Unit
-            _dataReadSuccess[16] = 0;          // Handshake
-            _dataReadSuccess[17] = 0;          // Status
-
         }
+
+        private ushort _testValue = 0;
 
         /*
         // Test for reading: 
@@ -133,22 +115,28 @@ namespace HBM.Weighing.API.WTX.Modbus
         public async Task<ushort> ReadTestModbus(Behavior behavior)
         {
             testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-            _wtxDevice = new WtxModbus(testConnection, 200,update);
+            _wtxDevice = new WtxModbus(testConnection, 200, UpdateReadTest);
 
             _wtxDevice.Connect(this.OnConnect, 100);
-
+          
             await Task.Run(async () =>
             {
                 ushort[] result = await testConnection.ReadAsync();
-                _wtxDevice.OnData(result);
-            });
 
-            return (ushort)_wtxDevice.ProcessData.NetValue;
+                _wtxDevice.ProcessData.UpdateProcessData(this, new DataEventArgs(testConnection.AllData));
+
+                //_wtxDevice.OnData(result);
+            });
+            
+            //return (ushort)_wtxDevice.ProcessData.NetValue;
+
+            return _testValue;
         }
         */
-        private void update(object sender, ProcessDataReceivedEventArgs e)
+
+        private void UpdateReadTest(object sender, ProcessDataReceivedEventArgs e)
         {
-            //throw new NotImplementedException();
+            _testValue = (ushort) e.ProcessData.NetValue;
         }
 
         // Test for checking the handshake bit 
@@ -156,7 +144,7 @@ namespace HBM.Weighing.API.WTX.Modbus
         public bool testHandshake(Behavior behavior)
         {
             testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-            _wtxDevice = new WtxModbus(testConnection, 200,update);
+            _wtxDevice = new WtxModbus(testConnection, 200,UpdateTestHandshake);
 
             _wtxDevice.Connect(this.OnConnect, 100);
 
@@ -165,12 +153,15 @@ namespace HBM.Weighing.API.WTX.Modbus
             return _wtxDevice.ProcessData.Handshake;
         }
 
+        private void UpdateTestHandshake(object sender, ProcessDataReceivedEventArgs e)
+        {
+        }
 
         [Test, TestCaseSource(typeof(ReadTestsModbus), "MeasureZeroTestCases")]
         public bool MeasureZeroTest(Behavior behavior)
         {
             testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-            _wtxDevice = new WtxModbus(testConnection, 200,update);
+            _wtxDevice = new WtxModbus(testConnection, 200,UpdateMeasureZeroTest);
 
             _wtxDevice.Connect(this.OnConnect, 100);
 
@@ -190,12 +181,16 @@ namespace HBM.Weighing.API.WTX.Modbus
             }
         }
 
+        private void UpdateMeasureZeroTest(object sender, ProcessDataReceivedEventArgs e)
+        {
+        }
+
         [Test, TestCaseSource(typeof(ReadTestsModbus), "ApplicationModeTestCases")]
         public int ApplicationModeTest(Behavior behavior)
         {
             TestModbusTCPConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
 
-            WtxModbus _wtxDevice = new WtxModbus(testConnection, 200,update);
+            WtxModbus _wtxDevice = new WtxModbus(testConnection, 200,UpdateApplicationModeTest);
 
             _wtxDevice.Connect(this.OnConnect, 100);
 
@@ -208,11 +203,15 @@ namespace HBM.Weighing.API.WTX.Modbus
             //return _wtxDevice.ApplicationMode;
         }
 
+        private void UpdateApplicationModeTest(object sender, ProcessDataReceivedEventArgs e)
+        {
+        }
+
         [Test, TestCaseSource(typeof(ReadTestsModbus), "LogEventTestCases")]
         public async Task<bool> LogEventGetTest(Behavior behavior)
         {
             testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-            _wtxDevice = new WtxModbus(testConnection, 200,update);
+            _wtxDevice = new WtxModbus(testConnection, 200,UpdateLogEventGetTest);
 
             _wtxDevice.Connect(this.OnConnect, 100);
             testConnection.IsConnected = true;
@@ -231,11 +230,15 @@ namespace HBM.Weighing.API.WTX.Modbus
             //return _wtxDevice.ApplicationMode;
         }
 
+        private void UpdateLogEventGetTest(object sender, ProcessDataReceivedEventArgs e)
+        {
+        }
+
         [Test, TestCaseSource(typeof(ReadTestsModbus), "LogEventTestCases")]
         public async Task<bool> LogEventSetTest(Behavior behavior)
         {
             testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-            _wtxDevice = new WtxModbus(testConnection, 200,update);
+            _wtxDevice = new WtxModbus(testConnection, 200, UpdateLogEventSetTest);
 
             _wtxDevice.Connect(this.OnConnect, 100);
             testConnection.IsConnected = true;
@@ -252,6 +255,10 @@ namespace HBM.Weighing.API.WTX.Modbus
             else
                 return false;
             //return _wtxDevice.ApplicationMode;
+        }
+
+        private void UpdateLogEventSetTest(object sender, ProcessDataReceivedEventArgs e)
+        {
         }
 
 

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -173,6 +173,10 @@ namespace HBM.Weighing.API.WTX.Modbus
         public event EventHandler BusActivityDetection;
         public event EventHandler<DataEventArgs> IncomingDataReceived;
         public event EventHandler<DataEventArgs> UpdateDataClasses;
+        
+        private Dictionary<string, int> _dataIntegerBuffer;
+
+        private ICommands _commands;
 
         private string IP;
         private int interval;
@@ -187,6 +191,12 @@ namespace HBM.Weighing.API.WTX.Modbus
             _dataWTX = new ushort[38];
             // size of 38 elements for the standard and filler application mode.            
 
+            _commands = new ModbusCommands();
+
+             _dataIntegerBuffer = new Dictionary<string, int>();
+
+            this.CreateDictionary();
+           
             this.behavior = behavior;
 
             this.numPoints = 6;
@@ -220,7 +230,7 @@ namespace HBM.Weighing.API.WTX.Modbus
                     break; 
             }
 
-            Write(Convert.ToString(0), 0); //Dummyaufruf hier, damit Tests erst mal funktionieren
+            Write(Convert.ToString(0), 0);
     }
 
         public bool IsConnected
@@ -253,6 +263,139 @@ namespace HBM.Weighing.API.WTX.Modbus
             }
         }
 
+
+        private void CreateDictionary()
+        {
+            _dataIntegerBuffer.Add(_commands.NET_VALUE, 0);
+            _dataIntegerBuffer.Add(_commands.GROSS_VALUE, 0);
+
+            _dataIntegerBuffer.Add(_commands.WEIGHING_DEVICE_1_WEIGHT_STATUS, 0);
+            _dataIntegerBuffer.Add(_commands.UNIT_PREFIX_FIXED_PARAMETER, 0);
+
+            _dataIntegerBuffer.Add(_commands.FINE_FLOW_CUT_OFF_POINT, 0);
+            _dataIntegerBuffer.Add(_commands.COARSE_FLOW_CUT_OFF_POINT, 0);
+            _dataIntegerBuffer.Add(_commands.DECIMALS, 0);
+            _dataIntegerBuffer.Add(_commands.APPLICATION_MODE, 0);
+            _dataIntegerBuffer.Add(_commands.SCALE_COMMAND_STATUS, 0);
+
+            _dataIntegerBuffer.Add(_commands.COARSE_FLOW_MONITORING, 0);
+            _dataIntegerBuffer.Add(_commands.FINE_FLOW_MONITORING, 0);
+            _dataIntegerBuffer.Add(_commands.EMPTYING_MODE, 0);
+            _dataIntegerBuffer.Add(_commands.MAXIMAL_DOSING_TIME, 0);
+
+            _dataIntegerBuffer.Add(_commands.UPPER_TOLERANCE_LIMIT, 0);
+            _dataIntegerBuffer.Add(_commands.LOWER_TOLERANCE_LIMIT, 0);
+
+            //_dataIntegerBuffer.Add(_commands.DOSING_STATE, 0);
+            //_dataIntegerBuffer.Add(_commands.DOSING_RESULT, 0);
+
+            _dataIntegerBuffer.Add(_commands.DOSING_TIME, 0);
+            _dataIntegerBuffer.Add(_commands.COARSE_FLOW_TIME, 0);
+            _dataIntegerBuffer.Add(_commands.FINE_FLOW_TIME, 0);
+            _dataIntegerBuffer.Add(_commands.RANGE_SELECTION_PARAMETER, 0);
+
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_INPUT_1, 0);
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_INPUT_2, 0);
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_INPUT_3, 0);
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_INPUT_4, 0);
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_OUTPUT_1, 0);
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_OUTPUT_2, 0);
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_OUTPUT_3, 0);
+            _dataIntegerBuffer.Add(_commands.STATUS_DIGITAL_OUTPUT_4, 0);
+
+            _dataIntegerBuffer.Add(_commands.LIMIT_VALUE, 0);
+
+            _dataIntegerBuffer.Add(_commands.LIMIT_VALUE_MONITORING_LIV11, 0); ;
+            _dataIntegerBuffer.Add(_commands.SIGNAL_SOURCE_LIV12, 0);
+            _dataIntegerBuffer.Add(_commands.SWITCH_ON_LEVEL_LIV13, 0);
+            _dataIntegerBuffer.Add(_commands.SWITCH_OFF_LEVEL_LIV14, 0);
+
+            _dataIntegerBuffer.Add(_commands.LIMIT_VALUE_MONITORING_LIV21, 0);
+            _dataIntegerBuffer.Add(_commands.SIGNAL_SOURCE_LIV22, 0);
+            _dataIntegerBuffer.Add(_commands.SWITCH_ON_LEVEL_LIV23, 0);
+            _dataIntegerBuffer.Add(_commands.SWITCH_OFF_LEVEL_LIV24, 0); ;
+
+            _dataIntegerBuffer.Add(_commands.LIMIT_VALUE_MONITORING_LIV31, 0);
+            _dataIntegerBuffer.Add(_commands.SIGNAL_SOURCE_LIV32, 0);
+            _dataIntegerBuffer.Add(_commands.SWITCH_ON_LEVEL_LIV33, 0);
+            _dataIntegerBuffer.Add(_commands.SWITCH_OFF_LEVEL_LIV34, 0);
+
+            _dataIntegerBuffer.Add(_commands.LIMIT_VALUE_MONITORING_LIV41, 0);
+            _dataIntegerBuffer.Add(_commands.SIGNAL_SOURCE_LIV42, 0);
+            _dataIntegerBuffer.Add(_commands.SWITCH_ON_LEVEL_LIV43, 0); ;
+            _dataIntegerBuffer.Add(_commands.SWITCH_OFF_LEVEL_LIV44, 0);
+        }
+
+
+        private void UpdateDictionary()
+        {
+            // Process data : 
+
+            _dataIntegerBuffer[_commands.NET_VALUE] = _dataWTX[1] + (_dataWTX[0] << 16);
+            _dataIntegerBuffer[_commands.GROSS_VALUE] = _dataWTX[3] + (_dataWTX[2] << 16);
+            _dataIntegerBuffer[_commands.WEIGHING_DEVICE_1_WEIGHT_STATUS] = _dataWTX[4];
+            _dataIntegerBuffer[_commands.SCALE_COMMAND_STATUS] = _dataWTX[5];                       // status -> Measured value status
+            _dataIntegerBuffer[_commands.STATUS_DIGITAL_INPUT_1] = _dataWTX[6];
+            _dataIntegerBuffer[_commands.STATUS_DIGITAL_OUTPUT_1] = _dataWTX[7];
+            _dataIntegerBuffer[_commands.LIMIT_VALUE] = _dataWTX[8];
+            _dataIntegerBuffer[_commands.FINE_FLOW_CUT_OFF_POINT] = _dataWTX[20];
+            _dataIntegerBuffer[_commands.COARSE_FLOW_CUT_OFF_POINT] = _dataWTX[22];
+
+            _dataIntegerBuffer[_commands.APPLICATION_MODE] = _dataWTX[5] & 0x1;                      // application mode 
+            _dataIntegerBuffer[_commands.DECIMALS] = (_dataWTX[5] & 0x70) >> 4;                      // decimals
+            _dataIntegerBuffer[_commands.UNIT_PREFIX_FIXED_PARAMETER] = (_dataWTX[5] & 0x180) >> 7;  // unit
+
+            _dataIntegerBuffer[_commands.COARSE_FLOW_MONITORING] = _dataWTX[8] & 0x1;         //_coarseFlow
+            _dataIntegerBuffer[_commands.FINE_FLOW_MONITORING] = ((_dataWTX[8] & 0x2) >> 1);  // _fineFlow
+
+            _dataIntegerBuffer[_commands.EMPTYING_MODE] = ((_dataWTX[8] & 0x10) >> 4);
+            _dataIntegerBuffer[_commands.MAXIMAL_DOSING_TIME] = ((_dataWTX[8] & 0x100) >> 8);
+            _dataIntegerBuffer[_commands.UPPER_TOLERANCE_LIMIT] = ((_dataWTX[8] & 0x400) >> 10);
+            _dataIntegerBuffer[_commands.LOWER_TOLERANCE_LIMIT] = ((_dataWTX[8] & 0x800) >> 11);
+            _dataIntegerBuffer[_commands.STATUS_DIGITAL_INPUT_1] = ((_dataWTX[8] & 0x4000) >> 14);
+
+            _dataIntegerBuffer[_commands.DOSING_RESULT] = _dataWTX[12];
+            _dataIntegerBuffer[_commands.MEAN_VALUE_DOSING_RESULTS] = _dataWTX[14];
+            _dataIntegerBuffer[_commands.STANDARD_DEVIATION] = _dataWTX[16];
+            _dataIntegerBuffer[_commands.DOSING_TIME] = _dataWTX[24];                 // _currentDosingTime = _dataWTX[24];
+
+            _dataIntegerBuffer[_commands.COARSE_FLOW_TIME] = _dataWTX[25];            // _currentCoarseFlowTime
+            _dataIntegerBuffer[_commands.FINE_FLOW_TIME] = _dataWTX[26];              // _currentFineFlowTime
+            _dataIntegerBuffer[_commands.RANGE_SELECTION_PARAMETER] = _dataWTX[27];   // _parameterSetProduct
+
+            _dataIntegerBuffer[_commands.LIMIT_VALUE] = _dataWTX[8];
+
+            // Standard data: Missing ID's
+            /*
+                _limitStatus1 = (_dataWTX[8] & 0x1); ;
+                _limitStatus2 = ((_dataWTX[8] & 0x2) >> 1);
+                _limitStatus3 = ((_dataWTX[8] & 0x4) >> 2);
+                _limitStatus4 = ((_dataWTX[8] & 0x8) >> 3);
+                _weightMemDay = (_dataWTX[9]);
+                _weightMemMonth = (_dataWTX[10]);
+                _weightMemYear = (_dataWTX[11]);
+                _weightMemSeqNumber = (_dataWTX[12]);
+                _weightMemGross = (_dataWTX[13]);
+                _weightMemNet = (_dataWTX[14]);
+           */
+
+            // Filler data: Missing ID's
+            /*
+                _ready = ((_dataWTX[8] & 0x4) >> 2);
+                _reDosing = ((_dataWTX[8] & 0x8) >> 3)
+                _emptying = ((_dataWTX[8] & 0x10) >> 4);
+                _flowError = ((_dataWTX[8] & 0x20) >> 5);
+                _alarm = ((_dataWTX[8] & 0x40) >> 6);
+                _adcOverUnderload = ((_dataWTX[8] & 0x80) >> 7);           
+                _legalForTradeOperation = ((_dataWTX[8] & 0x200) >> 9);
+                _statusInput1 = ((_dataWTX[8] & 0x4000) >> 14);
+                _generalScaleError = ((_dataWTX[8] & 0x8000) >> 15);
+                _fillingProcessStatus = _dataWTX[9];
+                _numberDosingResults = _dataWTX[11];          
+                _totalWeight = _dataWTX[18];
+            */
+
+        }
 
         public int Read(object index)
         {
@@ -379,7 +522,11 @@ namespace HBM.Weighing.API.WTX.Modbus
                     break;
             }
 
-            IncomingDataReceived?.Invoke(this, null/*new ProcessDataReceivedEventArgs(new ProcessData())*/);
+            _dataIntegerBuffer["0"] = 1;
+
+            this.UpdateDictionary();
+            // Updata data in data classes : 
+            this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
 
             return _dataWTX[Convert.ToInt16(index)];
         }
@@ -662,7 +809,7 @@ namespace HBM.Weighing.API.WTX.Modbus
         {
             ushort[] value = new ushort[1];
             await Task.Run(async () =>
-             {
+            {
             switch (behavior)
             {
                 case Behavior.ReadFail:
@@ -683,7 +830,7 @@ namespace HBM.Weighing.API.WTX.Modbus
                 case Behavior.ReadSuccess:
 
                     // The most important data attributes from the WTX120 device: 
-
+                    
                     _dataWTX[0] = 0x0000;
                     _dataWTX[1] = 0x4040;
                     _dataWTX[2] = 0x0000;
@@ -833,10 +980,19 @@ namespace HBM.Weighing.API.WTX.Modbus
             {
                 _dataWTX[5] = 0x0000;
             }
+            
+                this.UpdateDictionary();
+                // Update data in data classes : 
+                this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
 
-            return _dataWTX;
+                return _dataWTX;
 
              });
+
+            this.UpdateDictionary();
+            // Update data in data classes : 
+            this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
+
             return _dataWTX;
         }
 
@@ -873,11 +1029,11 @@ namespace HBM.Weighing.API.WTX.Modbus
         }
 
 
-        Dictionary<string, int> INetConnection.AllData
+        public Dictionary<string, int> AllData
         {
             get
             {
-                throw new NotImplementedException();
+                return this._dataIntegerBuffer;
             }
         }
 
@@ -975,8 +1131,13 @@ namespace HBM.Weighing.API.WTX.Modbus
             get { return "Modbus"; }
         }
 
-        public ICommands IDCommands { get; set; }
-
+        public ICommands IDCommands
+        {
+            get
+            {
+                return this._commands;
+            }
+        }
         //public Dictionary<string, JToken> getDataBuffer => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
-Enabling to read from index/command 'limit value status' (bit masking&shifting with brackets!). Using method the 'index(IDCommand)' with '.Split(deletedString)'.