### PR TITLE
Changes in Data classes for writing output words (using WriteArray(..) ; BaseWtDevice restart and stop data update methods; Simple contructor in WtxModbus; CL & GUIsimple : Simplify update method. 

### DIFF
--- a/Examples/CommandLine/Program.cs
+++ b/Examples/CommandLine/Program.cs
@@ -373,6 +373,8 @@ namespace WTXModbus
         {
             //_isCalibrating = true;
 
+            _wtxDevice.StopUpdate();
+
             zero_load_nominal_load_input();
            
             _wtxDevice.Calculate(_preload,_capacity);
@@ -387,9 +389,7 @@ namespace WTXModbus
          */
         private static void CalibrationWithWeight()
         {
-            //_isCalibrating = true;
-
-            //WTXObj.stopTimer();    // The timer is stopped in the method 'Calculate(..)' in class WTX120_Modbus.
+            _wtxDevice.StopUpdate();
 
             Console.Clear();
             Console.WriteLine("\nPlease tip the value for the calibration weight and tip enter to confirm : ");
@@ -405,9 +405,7 @@ namespace WTXModbus
 
             _wtxDevice.Calibrate(PotencyCalibrationWeight(), _calibrationWeight);
 
-            //WTXObj.restartTimer();   // The timer is restarted in the method 'Calculate(..)' in class WTX120_Modbus.
-
-            //_isCalibrating = false;
+            _wtxDevice.RestartUpdate();
         }  
 
         /*
@@ -464,54 +462,54 @@ namespace WTXModbus
 
                     if (_inputMode == 1)
                     {
-                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) + "\t  As an Integer:  " + e.ProcessData.NetValue);
+                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) + "\t  As an int/bool:  " + e.ProcessData.NetValue);
                     }
                     else
                         if (_inputMode == 2 || _inputMode == 3 || _inputMode == 4)
                     {
-                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +   "\t  As an Integer:  " + e.ProcessData.NetValue);
-                        Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + "\t  As an Integer:  " + e.ProcessData.GrossValue);
+                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +   "\t  As an int/bool:  " + e.ProcessData.NetValue);
+                        Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + "\t  As an int/bool:  " + e.ProcessData.GrossValue);
                     }
                     else
                        if (_inputMode == 5)
                     {
-                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +   "\t  As an Integer:  " + e.ProcessData.NetValue);
-                        Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + "\t  As an Integer:  " + e.ProcessData.GrossValue);
-                        Console.WriteLine("General weight error:          " + e.ProcessData.GeneralWeightError.ToString() + "\t  As an Integer:  " + e.ProcessData.GeneralWeightError);
-                        Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +        "\t  As an Integer:  " + e.ProcessData.LimitStatus);
-                        Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() +    "\t  As an Integer:  " + e.ProcessData.ScaleSealIsOpen);
-                        Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +         "\t  As an Integer:  " + e.ProcessData.ManualTare);
-                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an Integer:  " + e.ProcessData.WeightType);
-                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an Integer:  " + e.ProcessData.ScaleRange);
-                        Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +       "\t  As an Integer:  " + e.ProcessData.ZeroRequired);
-                        Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightWithinTheCenterOfZero);
-                        Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() +  "\t  As an Integer:  " + e.ProcessData.WeightInZeroRange);
+                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +   "\t  As an int/bool:  " + e.ProcessData.NetValue);
+                        Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + "\t  As an int/bool:  " + e.ProcessData.GrossValue);
+                        Console.WriteLine("General weight error:          " + e.ProcessData.GeneralWeightError.ToString() + "\t  As an int/bool:  " + e.ProcessData.GeneralWeightError);
+                        Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +        "\t  As an int/bool:  " + e.ProcessData.LimitStatus);
+                        Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() +    "\t  As an int/bool:  " + e.ProcessData.ScaleSealIsOpen);
+                        Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +         "\t  As an int/bool:  " + e.ProcessData.ManualTare);
+                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an int/bool:  " + e.ProcessData.WeightType);
+                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an int/bool:  " + e.ProcessData.ScaleRange);
+                        Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +       "\t  As an int/bool:  " + e.ProcessData.ZeroRequired);
+                        Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an int/bool:  " + e.ProcessData.WeightWithinTheCenterOfZero);
+                        Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() +  "\t  As an int/bool:  " + e.ProcessData.WeightInZeroRange);
 
-                        Console.WriteLine("Limit status:                  " + e.ProcessData.LimitStatus.ToString() + "        As an Integer:  " + e.ProcessData.LimitStatus);
-                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an Integer: " + e.ProcessData.WeightMoving);
+                        Console.WriteLine("Limit status:                  " + e.ProcessData.LimitStatus.ToString() + "        As an int/bool:  " + e.ProcessData.LimitStatus);
+                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an int/bool: " + e.ProcessData.WeightMoving);
                     }
                     else
                     if (_inputMode == 6 || _inputMode == 38)
                     { 
-                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +  "\t  As an Integer:  " + e.ProcessData.NetValue);
-                        Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals)+ "\t  As an Integer:  " + e.ProcessData.GrossValue);
-                        Console.WriteLine("General weight error:          " + e.ProcessData.GeneralWeightError.ToString() +                  "\t  As an Integer:  " + e.ProcessData.GeneralWeightError);
-                        Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +                         "\t  As an Integer:  " + e.ProcessData.LimitStatus);
-                        Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() +                     "\t  As an Integer:  " + e.ProcessData.ScaleSealIsOpen);
-                        Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +        "\t  As an Integer:  " + e.ProcessData.ManualTare);
-                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an Integer:  " + e.ProcessData.WeightType);
-                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an Integer:  " + e.ProcessData.ScaleRange);
-                        Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +      "\t  As an Integer:  " + e.ProcessData.ZeroRequired);
-                        Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightWithinTheCenterOfZero);
-                        Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightInZeroRange);
-                        Console.WriteLine("Application mode:              " + _wtxDevice.ApplicationMode.ToString() + "\t  As an Integer:  " + _wtxDevice.ApplicationMode.ToString());
-                        Console.WriteLine("Decimal places:                " + e.ProcessData.Decimals.ToString() +          "\t  As an Integer:  " + e.ProcessData.Decimals);
-                        Console.WriteLine("Unit:                          " + _wtxDevice.Unit +                       "\t  As an Integer:  " + e.ProcessData.Unit);
-                        Console.WriteLine("Handshake:                     " + e.ProcessData.Handshake.ToString() +         "\t  As an Integer:  " + e.ProcessData.Handshake);
-                        Console.WriteLine("Status:                        " + statusCommentMethod() + "\t  As an Integer:  " + e.ProcessData.Status);
+                        Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +  "\t  As an int/bool:  " + e.ProcessData.NetValue);
+                        Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals)+ "\t  As an int/bool:  " + e.ProcessData.GrossValue);
+                        Console.WriteLine("General weight error:          " + e.ProcessData.GeneralWeightError.ToString() +                  "\t  As an int/bool:  " + e.ProcessData.GeneralWeightError);
+                        Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +                         "\t  As an int/bool:  " + e.ProcessData.LimitStatus);
+                        Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() +                     "\t  As an int/bool:  " + e.ProcessData.ScaleSealIsOpen);
+                        Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +        "\t  As an int/bool:  " + e.ProcessData.ManualTare);
+                        Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType + "\t  As an int/bool:  " + e.ProcessData.WeightType);
+                        Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange + "\t  As an int/bool:  " + e.ProcessData.ScaleRange);
+                        Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +      "\t  As an int/bool:  " + e.ProcessData.ZeroRequired);
+                        Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an int/bool:  " + e.ProcessData.WeightWithinTheCenterOfZero);
+                        Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() + "\t  As an int/bool:  " + e.ProcessData.WeightInZeroRange);
+                        Console.WriteLine("Application mode:              " + _wtxDevice.ApplicationMode.ToString() + "\t  As an int/bool:  " + _wtxDevice.ApplicationMode.ToString());
+                        Console.WriteLine("Decimal places:                " + e.ProcessData.Decimals.ToString() +          "\t  As an int/bool:  " + e.ProcessData.Decimals);
+                        Console.WriteLine("Unit:                          " + _wtxDevice.Unit +                       "\t  As an int/bool:  " + e.ProcessData.Unit);
+                        Console.WriteLine("Handshake:                     " + e.ProcessData.Handshake.ToString() +         "\t  As an int/bool:  " + e.ProcessData.Handshake);
+                        Console.WriteLine("Status:                        " + statusCommentMethod() + "\t  As an int/bool:  " + e.ProcessData.Status);
 
-                        Console.WriteLine("Limit status:                  " + limitCommentMethod() + "       As an Integer:  " + e.ProcessData.LimitStatus);
-                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "         As an Integer: " + e.ProcessData.WeightMoving);
+                        Console.WriteLine("Limit status:                  " + limitCommentMethod() + "       As an int/bool:  " + e.ProcessData.LimitStatus);
+                        Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "         As an int/bool: " + e.ProcessData.WeightMoving);
 
                     }
                     else
@@ -519,77 +517,77 @@ namespace WTXModbus
                 }
                 else
                 {
-                    Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +   "\t  As an Integer:  " + e.ProcessData.NetValue);
-                    Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + "\t  As an Integer:  " + e.ProcessData.GrossValue);
-                    Console.WriteLine("General weight error:          " + e.ProcessData.GeneralWeightError.ToString() +                   "\t  As an Integer:  " + e.ProcessData.GeneralWeightError);
-                    Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +     "\t  As an Integer:  " + e.ProcessData.LimitStatus);
-                    Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() + "\t  As an Integer:  " + e.ProcessData.ScaleSealIsOpen);
-                    Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +      "\t  As an Integer:  " + e.ProcessData.ManualTare);
-                    Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType +               "\t  As an Integer:  " + e.ProcessData.WeightType);
-                    Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange +               "\t  As an Integer:  " + e.ProcessData.ScaleRange);
-                    Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +    "\t  As an Integer:  " + e.ProcessData.ZeroRequired);
-                    Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an Integer:  " + e.ProcessData.WeightWithinTheCenterOfZero);
-                    Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() +           "\t  As an Integer:  " + e.ProcessData.WeightInZeroRange);
-                    Console.WriteLine("Application mode:              " + _wtxDevice.ApplicationMode.ToString() +           "\t  As an Integer:  " + _wtxDevice.ApplicationMode);
-                    Console.WriteLine("Decimal places:                " + e.ProcessData.Decimals.ToString() +         "\t  As an Integer:  " + e.ProcessData.Decimals);
-                    Console.WriteLine("Unit:                          " + _wtxDevice.Unit +                      "\t  As an Integer:  " + e.ProcessData.Unit);
-                    Console.WriteLine("Handshake:                     " + e.ProcessData.Handshake.ToString() +        "\t  As an Integer:  " + e.ProcessData.Handshake);
-                    Console.WriteLine("Status:                        " + statusCommentMethod() +                    "\t  As an Integer:  " + e.ProcessData.Status);
+                    Console.WriteLine("Net value:                     " + _wtxDevice.CurrentWeight(e.ProcessData.NetValue, e.ProcessData.Decimals) +   "\t  As an int/bool:  " + e.ProcessData.NetValue);
+                    Console.WriteLine("Gross value:                   " + _wtxDevice.CurrentWeight(e.ProcessData.GrossValue, e.ProcessData.Decimals) + "\t  As an int/bool:  " + e.ProcessData.GrossValue);
+                    Console.WriteLine("General weight error:          " + e.ProcessData.GeneralWeightError.ToString() +                   "\t  As an int/bool:  " + e.ProcessData.GeneralWeightError);
+                    Console.WriteLine("Scale alarm triggered:         " + e.ProcessData.LimitStatus.ToString() +     "\t  As an int/bool:  " + e.ProcessData.LimitStatus);
+                    Console.WriteLine("Scale seal is open:            " + e.ProcessData.ScaleSealIsOpen.ToString() + "\t  As an int/bool:  " + e.ProcessData.ScaleSealIsOpen);
+                    Console.WriteLine("Manual tare:                   " + e.ProcessData.ManualTare.ToString() +      "\t  As an int/bool:  " + e.ProcessData.ManualTare);
+                    Console.WriteLine("Weight type:                   " + e.ProcessData.WeightType +               "\t  As an int/bool:  " + e.ProcessData.WeightType);
+                    Console.WriteLine("Scale range:                   " + e.ProcessData.ScaleRange +               "\t  As an int/bool:  " + e.ProcessData.ScaleRange);
+                    Console.WriteLine("Zero required/True zero:       " + e.ProcessData.ZeroRequired.ToString() +    "\t  As an int/bool:  " + e.ProcessData.ZeroRequired);
+                    Console.WriteLine("Weight within center of zero:  " + e.ProcessData.WeightWithinTheCenterOfZero.ToString() + "\t  As an int/bool:  " + e.ProcessData.WeightWithinTheCenterOfZero);
+                    Console.WriteLine("Weight in zero range:          " + e.ProcessData.WeightInZeroRange.ToString() +           "\t  As an int/bool:  " + e.ProcessData.WeightInZeroRange);
+                    Console.WriteLine("Application mode:              " + _wtxDevice.ApplicationMode.ToString() +           "\t  As an int/bool:  " + _wtxDevice.ApplicationMode);
+                    Console.WriteLine("Decimal places:                " + e.ProcessData.Decimals.ToString() +         "\t  As an int/bool:  " + e.ProcessData.Decimals);
+                    Console.WriteLine("Unit:                          " + _wtxDevice.Unit +                      "\t  As an int/bool:  " + e.ProcessData.Unit);
+                    Console.WriteLine("Handshake:                     " + e.ProcessData.Handshake.ToString() +        "\t  As an int/bool:  " + e.ProcessData.Handshake);
+                    Console.WriteLine("Status:                        " + statusCommentMethod() +                    "\t  As an int/bool:  " + e.ProcessData.Status);
 
-                    Console.WriteLine("Limit status:                  " + limitCommentMethod() +  "     As an Integer:  " + e.ProcessData.LimitStatus);
-                    Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an Integer:  " + e.ProcessData.WeightMoving);
+                    Console.WriteLine("Limit status:                  " + limitCommentMethod() +  "     As an int/bool:  " + e.ProcessData.LimitStatus);
+                    Console.WriteLine("Weight moving:                 " + e.ProcessData.WeightMoving.ToString() + "          As an int/bool:  " + e.ProcessData.WeightMoving);
 
                     if (_showAllInputWords == true)
                     {
 
-                        Console.WriteLine("Digital input  1:              " + ((WtxModbus)_wtxDevice).DataStandard.Input1.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Input1);
-                        Console.WriteLine("Digital input  2:              " + ((WtxModbus)_wtxDevice).DataStandard.Input2.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Input2);
-                        Console.WriteLine("Digital input  3:              " + ((WtxModbus)_wtxDevice).DataStandard.Input3.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Input3);
-                        Console.WriteLine("Digital input  4:              " + ((WtxModbus)_wtxDevice).DataStandard.Input4.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Input4);
+                        Console.WriteLine("Digital input  1:              " + ((WtxModbus)_wtxDevice).DataStandard.Input1.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Input1);
+                        Console.WriteLine("Digital input  2:              " + ((WtxModbus)_wtxDevice).DataStandard.Input2.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Input2);
+                        Console.WriteLine("Digital input  3:              " + ((WtxModbus)_wtxDevice).DataStandard.Input3.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Input3);
+                        Console.WriteLine("Digital input  4:              " + ((WtxModbus)_wtxDevice).DataStandard.Input4.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Input4);
 
-                        Console.WriteLine("Digital output 1:              " + ((WtxModbus)_wtxDevice).DataStandard.Output1.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Output1);
-                        Console.WriteLine("Digital output 2:              " + ((WtxModbus)_wtxDevice).DataStandard.Output2.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Output2);
-                        Console.WriteLine("Digital output 3:              " + ((WtxModbus)_wtxDevice).DataStandard.Output3.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Output3);
-                        Console.WriteLine("Digital output 4:              " + ((WtxModbus)_wtxDevice).DataStandard.Output4.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.Output4);
+                        Console.WriteLine("Digital output 1:              " + ((WtxModbus)_wtxDevice).DataStandard.Output1.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Output1);
+                        Console.WriteLine("Digital output 2:              " + ((WtxModbus)_wtxDevice).DataStandard.Output2.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Output2);
+                        Console.WriteLine("Digital output 3:              " + ((WtxModbus)_wtxDevice).DataStandard.Output3.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Output3);
+                        Console.WriteLine("Digital output 4:              " + ((WtxModbus)_wtxDevice).DataStandard.Output4.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.Output4);
 
-                        Console.WriteLine("Coarse flow:                   " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlow.ToString() +  "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlow);
-                        Console.WriteLine("Fine flow:                     " + ((WtxModbus)_wtxDevice).DataFiller.FineFlow.ToString() +    "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.FineFlow);
-                        Console.WriteLine("Ready:                         " + ((WtxModbus)_wtxDevice).DataFiller.Ready.ToString() +       "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.Ready);
-                        Console.WriteLine("Re-dosing:                     " + ((WtxModbus)_wtxDevice).DataFiller.ReDosing.ToString() +    "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.ReDosing);
+                        Console.WriteLine("Coarse flow:                   " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlow.ToString() +  "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlow);
+                        Console.WriteLine("Fine flow:                     " + ((WtxModbus)_wtxDevice).DataFiller.FineFlow.ToString() +    "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.FineFlow);
+                        Console.WriteLine("Ready:                         " + ((WtxModbus)_wtxDevice).DataFiller.Ready.ToString() +       "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.Ready);
+                        Console.WriteLine("Re-dosing:                     " + ((WtxModbus)_wtxDevice).DataFiller.ReDosing.ToString() +    "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.ReDosing);
 
-                        Console.WriteLine("Emptying:                      " + ((WtxModbus)_wtxDevice).DataFiller.Emptying.ToString() +          "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.Emptying);
-                        Console.WriteLine("Flow error:                    " + ((WtxModbus)_wtxDevice).DataFiller.FlowError.ToString() +         "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.FlowError);
-                        Console.WriteLine("Alarm:                         " + ((WtxModbus)_wtxDevice).DataFiller.Alarm.ToString() +             "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.Alarm);
-                        Console.WriteLine("ADC Overload/Unterload:        " + ((WtxModbus)_wtxDevice).DataFiller.AdcOverUnderload.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.AdcOverUnderload);
+                        Console.WriteLine("Emptying:                      " + ((WtxModbus)_wtxDevice).DataFiller.Emptying.ToString() +          "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.Emptying);
+                        Console.WriteLine("Flow error:                    " + ((WtxModbus)_wtxDevice).DataFiller.FlowError.ToString() +         "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.FlowError);
+                        Console.WriteLine("Alarm:                         " + ((WtxModbus)_wtxDevice).DataFiller.Alarm.ToString() +             "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.Alarm);
+                        Console.WriteLine("ADC Overload/Unterload:        " + ((WtxModbus)_wtxDevice).DataFiller.AdcOverUnderload.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.AdcOverUnderload);
 
-                        Console.WriteLine("Max.Dosing time:               " + ((WtxModbus)_wtxDevice).DataFiller.MaxDosingTime.ToString() +          "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.MaxDosingTime);
-                        Console.WriteLine("Legal-for-trade operation:     " + ((WtxModbus)_wtxDevice).DataFiller.LegalForTradeOperation.ToString() +           "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.LegalForTradeOperation);
-                        Console.WriteLine("Tolerance error+:              " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorPlus.ToString() +     "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorPlus);
-                        Console.WriteLine("Tolerance error-:              " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorMinus.ToString() +    "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorMinus);
+                        Console.WriteLine("Max.Dosing time:               " + ((WtxModbus)_wtxDevice).DataFiller.MaxDosingTime.ToString() +          "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.MaxDosingTime);
+                        Console.WriteLine("Legal-for-trade operation:     " + ((WtxModbus)_wtxDevice).DataFiller.LegalForTradeOperation.ToString() +           "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.LegalForTradeOperation);
+                        Console.WriteLine("Tolerance error+:              " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorPlus.ToString() +     "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorPlus);
+                        Console.WriteLine("Tolerance error-:              " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorMinus.ToString() +    "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.ToleranceErrorMinus);
                                             
-                        Console.WriteLine("Status digital input 1:        " + ((WtxModbus)_wtxDevice).DataFiller.StatusInput1.ToString() +           "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.StatusInput1);
-                        Console.WriteLine("General scale error:           " + ((WtxModbus)_wtxDevice).DataFiller.GeneralScaleError.ToString() +      "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.GeneralScaleError);
-                        Console.WriteLine("Filling process status:        " + ((WtxModbus)_wtxDevice).DataFiller.FillingProcessStatus.ToString() +   "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.FillingProcessStatus);
-                        Console.WriteLine("Number of dosing results:      " + ((WtxModbus)_wtxDevice).DataFiller.NumberDosingResults.ToString() +    "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.NumberDosingResults);
+                        Console.WriteLine("Status digital input 1:        " + ((WtxModbus)_wtxDevice).DataFiller.StatusInput1.ToString() +           "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.StatusInput1);
+                        Console.WriteLine("General scale error:           " + ((WtxModbus)_wtxDevice).DataFiller.GeneralScaleError.ToString() +      "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.GeneralScaleError);
+                        Console.WriteLine("Filling process status:        " + ((WtxModbus)_wtxDevice).DataFiller.FillingProcessStatus.ToString() +   "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.FillingProcessStatus);
+                        Console.WriteLine("Number of dosing results:      " + ((WtxModbus)_wtxDevice).DataFiller.NumberDosingResults.ToString() +    "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.NumberDosingResults);
 
-                        Console.WriteLine("Dosing result:                 " + ((WtxModbus)_wtxDevice).DataFiller.DosingResult.ToString() +           "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.DosingResult);
-                        Console.WriteLine("Mean value of dosing results:  " + ((WtxModbus)_wtxDevice).DataFiller.MeanValueDosingResults.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.MeanValueDosingResults);
-                        Console.WriteLine("Standard deviation:            " + ((WtxModbus)_wtxDevice).DataFiller.StandardDeviation.ToString() +      "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.StandardDeviation);
-                        Console.WriteLine("Total weight:                  " + ((WtxModbus)_wtxDevice).DataFiller.TotalWeight.ToString() +            "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.TotalWeight);
+                        Console.WriteLine("Dosing result:                 " + ((WtxModbus)_wtxDevice).DataFiller.DosingResult.ToString() +           "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.DosingResult);
+                        Console.WriteLine("Mean value of dosing results:  " + ((WtxModbus)_wtxDevice).DataFiller.MeanValueDosingResults.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.MeanValueDosingResults);
+                        Console.WriteLine("Standard deviation:            " + ((WtxModbus)_wtxDevice).DataFiller.StandardDeviation.ToString() +      "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.StandardDeviation);
+                        Console.WriteLine("Total weight:                  " + ((WtxModbus)_wtxDevice).DataFiller.TotalWeight.ToString() +            "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.TotalWeight);
 
-                        Console.WriteLine("Fine flow cut-off point:       " + ((WtxModbus)_wtxDevice).DataFiller.FineFlowCutOffPoint.ToString() +    "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.FineFlowCutOffPoint);
-                        Console.WriteLine("Coarse flow cut-off point:     " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlowCutOffPoint.ToString() +  "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlowCutOffPoint);
-                        Console.WriteLine("Current dosing time:           " + ((WtxModbus)_wtxDevice).DataFiller.CurrentDosingTime.ToString() +      "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.CurrentDosingTime);
-                        Console.WriteLine("Current coarse flow time:      " + ((WtxModbus)_wtxDevice).DataFiller.CurrentCoarseFlowTime.ToString() +  "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.CurrentCoarseFlowTime);
-                        Console.WriteLine("Current fine flow time:        " + ((WtxModbus)_wtxDevice).DataFiller.CurrentFineFlowTime.ToString() +    "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.CurrentFineFlowTime);
+                        Console.WriteLine("Fine flow cut-off point:       " + ((WtxModbus)_wtxDevice).DataFiller.FineFlowCutOffPoint.ToString() +    "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.FineFlowCutOffPoint);
+                        Console.WriteLine("Coarse flow cut-off point:     " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlowCutOffPoint.ToString() +  "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.CoarseFlowCutOffPoint);
+                        Console.WriteLine("Current dosing time:           " + ((WtxModbus)_wtxDevice).DataFiller.CurrentDosingTime.ToString() +      "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.CurrentDosingTime);
+                        Console.WriteLine("Current coarse flow time:      " + ((WtxModbus)_wtxDevice).DataFiller.CurrentCoarseFlowTime.ToString() +  "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.CurrentCoarseFlowTime);
+                        Console.WriteLine("Current fine flow time:        " + ((WtxModbus)_wtxDevice).DataFiller.CurrentFineFlowTime.ToString() +    "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.CurrentFineFlowTime);
 
-                        Console.WriteLine("Parameter set (product):       " + ((WtxModbus)_wtxDevice).DataFiller.ParameterSetProduct.ToString() + "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataFiller.ParameterSetProduct);
-                        Console.WriteLine("Weight memory, Day:            " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemDay.ToString() +        "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemDay);
-                        Console.WriteLine("Weight memory, Month:          " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemMonth.ToString() +      "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemMonth);
-                        Console.WriteLine("Weight memory, Year:           " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemYear.ToString() +       "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemYear);
-                        Console.WriteLine("Weight memory, Seq.Number:     " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemSeqNumber.ToString() +  "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemSeqNumber);
-                        Console.WriteLine("Weight memory, gross:          " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemGross.ToString() +      "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemGross);
-                        Console.WriteLine("Weight memory, net:            " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemNet.ToString() +        "\t  As an Integer:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemNet);
+                        Console.WriteLine("Parameter set (product):       " + ((WtxModbus)_wtxDevice).DataFiller.ParameterSetProduct.ToString() + "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataFiller.ParameterSetProduct);
+                        Console.WriteLine("Weight memory, Day:            " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemDay.ToString() +        "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemDay);
+                        Console.WriteLine("Weight memory, Month:          " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemMonth.ToString() +      "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemMonth);
+                        Console.WriteLine("Weight memory, Year:           " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemYear.ToString() +       "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemYear);
+                        Console.WriteLine("Weight memory, Seq.Number:     " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemSeqNumber.ToString() +  "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemSeqNumber);
+                        Console.WriteLine("Weight memory, gross:          " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemGross.ToString() +      "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemGross);
+                        Console.WriteLine("Weight memory, net:            " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemNet.ToString() +        "\t  As an int/bool:  " + ((WtxModbus)_wtxDevice).DataStandard.WeightMemNet);
 
                         Console.WriteLine("\nPress 'a' again to hide the input words.");
                     }

--- a/Examples/GUIplc/GUIplc.cs
+++ b/Examples/GUIplc/GUIplc.cs
@@ -887,12 +887,12 @@ namespace WTXModbusExamples
          */
         private void calculateCalibrationToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _wtxDevice.StopTimer();
+            _wtxDevice.StopUpdate();
 
             _adjustmentCalculator = new AdjustmentCalculator(_wtxDevice);
             DialogResult res = _adjustmentCalculator.ShowDialog();
 
-            _wtxDevice.RestartTimer();
+            _wtxDevice.RestartUpdate();
         }
 
         /*
@@ -901,12 +901,12 @@ namespace WTXModbusExamples
          */
         private void calibrationWithWeightToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _wtxDevice.StopTimer();
+            _wtxDevice.StopUpdate();
 
             _adjustmentWeigher = new AdjustmentWeigher(_wtxDevice);
             DialogResult res = _adjustmentWeigher.ShowDialog();
 
-            _wtxDevice.RestartTimer();
+            _wtxDevice.RestartUpdate();
         }
 
 
@@ -932,7 +932,7 @@ namespace WTXModbusExamples
         {
             _wtxDevice.Calibrating = true;
 
-            _wtxDevice.StopTimer();
+            _wtxDevice.StopUpdate();
 
             _wtxDevice.Calculate(0, 2);
 

--- a/Examples/GUIsimple/GUIsimple.Designer.cs
+++ b/Examples/GUIsimple/GUIsimple.Designer.cs
@@ -210,6 +210,7 @@
             this.Controls.Add(this.grrpSetup);
             this.Name = "GUIsimple";
             this.Text = "GUIsimple";
+            this.Load += new System.EventHandler(this.GUIsimple_Load);
             this.grrpSetup.ResumeLayout(false);
             this.grrpSetup.PerformLayout();
             this.toolStrip1.ResumeLayout(false);

--- a/Examples/GUIsimple/GUIsimple.cs
+++ b/Examples/GUIsimple/GUIsimple.cs
@@ -119,6 +119,7 @@ namespace WTXGUIsimple
                 ModbusTcpConnection _modbusConnection = new ModbusTcpConnection(this._ipAddress);
 
                 _wtxDevice = new WtxModbus(_modbusConnection, this._timerInterval,update);
+
             }
             else
             {
@@ -168,10 +169,7 @@ namespace WTXGUIsimple
                 + "Gross:" + _wtxDevice.CurrentWeight(grossValue, decimals) + _wtxDevice.Unit + Environment.NewLine
                 + "Tara:" + _wtxDevice.CurrentWeight(taraValue, decimals) + _wtxDevice.Unit;
                 txtInfo.TextAlign = HorizontalAlignment.Right;
-            }));
 
-            txtInfo.BeginInvoke(new Action(() =>
-            {
                 if (e.ProcessData.Underload == true)
                 {
                     txtInfo.Text = "Underload : Lower than minimum" + Environment.NewLine;
@@ -259,5 +257,9 @@ namespace WTXGUIsimple
         }
         #endregion
 
+        private void GUIsimple_Load(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/HBM.Weighing.API/BaseWTDevice.cs
+++ b/HBM.Weighing.API/BaseWTDevice.cs
@@ -47,7 +47,6 @@ namespace HBM.Weighing.API
         #region Attributes
 
         protected INetConnection _connection;
-
         private IProcessData _processData;
 
         /// Eventhandler to raise an event and commit the data to the GUI/application from WTXJet and WTXModbus

--- a/HBM.Weighing.API/BaseWTDevice.cs
+++ b/HBM.Weighing.API/BaseWTDevice.cs
@@ -130,13 +130,6 @@ namespace HBM.Weighing.API
         public abstract void manualReDosing();
 
         /// <summary>
-        /// Sets the output via Jetbus or Modbus
-        /// </summary>
-        /// <param name="value">value to be written/set via Jet or Modbus</param>
-        /// <param name="index">path, index of the value to be set</param>
-        public abstract void SetOutput(object index, int value);
-
-        /// <summary>
         /// Synchronous call to disconnect
         /// </summary>
         public abstract void Disconnect();
@@ -202,6 +195,18 @@ namespace HBM.Weighing.API
         /// </summary>
         /// <returns></returns>
         public abstract string ScaleRangeStringComment();
+
+        /// <summary>
+        /// Stop the data update - Stop timer update
+        /// </summary>
+        /// <returns></returns>
+        public abstract void StopUpdate();
+
+        /// <summary>
+        /// Restart the data update - Restart timer update
+        /// </summary>
+        /// <returns></returns>
+        public abstract void RestartUpdate();
 
 
     }

--- a/HBM.Weighing.API/Data/DataFiller.cs
+++ b/HBM.Weighing.API/Data/DataFiller.cs
@@ -121,8 +121,7 @@ namespace HBM.Weighing.API.Data
         private int _emptyingMode;
 
         private INetConnection _connection;
-
-        private string _index;
+       
         #endregion
 
         #region contructor
@@ -132,9 +131,7 @@ namespace HBM.Weighing.API.Data
             _connection = Connection;
            
             _connection.UpdateDataClasses += UpdateFillerData;
-
-            _index = "";
-
+            
             _coarseFlow = 0;
             _fineFlow=0;
             _ready=0;
@@ -414,31 +411,31 @@ namespace HBM.Weighing.API.Data
         {
             get { return _residualFlowTime; }
             set {
-                  _connection.Write(this.getIndex(_connection.IDCommands.RESIDUAL_FLOW_TIME), value);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.RESIDUAL_FLOW_TIME), value);
                   this._residualFlowTime = value; }
         }
         public int TargetFillingWeight // Type : signed integer 32 Bit
         {
             get { return _targetFillingWeight; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.REFERENCE_VALUE_DOSING), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.REFERENCE_VALUE_DOSING), value);
                 this._targetFillingWeight = value; }
         }
         public int CoarseFlowCutOffPointSet // Type : signed integer 32 Bit
         {
             get { return _coarseFlowCutOffPointSet; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.COARSE_FLOW_CUT_OFF_POINT), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.COARSE_FLOW_CUT_OFF_POINT), value);
                 this._coarseFlowCutOffPointSet = value; }
         }
         public int FineFlowCutOffPointSet // Type : signed integer 32 Bit
         {
             get { return _fineFlowCutOffPointSet; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.FINE_FLOW_CUT_OFF_POINT), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.FINE_FLOW_CUT_OFF_POINT), value);
                 this._fineFlowCutOffPointSet = value; }
         }
         public int MinimumFineFlow // Type : signed integer 32 Bit
         {
             get { return _minimumFineFlow; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.MINIMUM_FINE_FLOW), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.MINIMUM_FINE_FLOW), value);
                 this._minimumFineFlow = value; }
         }
         public int OptimizationOfCutOffPoints // Type : unsigned integer 8 Bit
@@ -450,25 +447,25 @@ namespace HBM.Weighing.API.Data
         public int MaximumDosingTime // Type : unsigned integer 16 Bit
         {
             get { return _maximumDosingTime; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.MAXIMAL_DOSING_TIME), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.MAXIMAL_DOSING_TIME), value);
                 this._maximumDosingTime = value; }
         }
         public int StartWithFineFlow // Type : unsigned integer 16 Bit
         {
             get { return _startWithFineFlow; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.RUN_START_DOSING), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.RUN_START_DOSING), value);
                 this._startWithFineFlow = value; }
         }
         public int CoarseLockoutTime // Type : unsigned integer 16 Bit
         {
             get { return _coarseLockoutTime; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.LOCKOUT_TIME_COARSE_FLOW), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.LOCKOUT_TIME_COARSE_FLOW), value);
                 this._coarseLockoutTime = value; }
         }
         public int FineLockoutTime // Type : unsigned integer 16 Bit
         {
             get { return _fineLockoutTime; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.LOCKOUT_TIME_FINE_FLOW), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.LOCKOUT_TIME_FINE_FLOW), value);
                 this._fineLockoutTime = value; }
         }
         public int TareMode // Type : unsigned integer 8 Bit
@@ -480,55 +477,55 @@ namespace HBM.Weighing.API.Data
         public int UpperToleranceLimit // Type : signed integer 32 Bit
         {
             get { return _upperToleranceLimit; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.UPPER_TOLERANCE_LIMIT), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.UPPER_TOLERANCE_LIMIT), value);
                 this._upperToleranceLimit = value; }
         }
         public int LowerToleranceLimit // Type : signed integer 32 Bit
         {
             get { return _lowerToleranceLimit; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.LOWER_TOLERANCE_LIMIT), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.LOWER_TOLERANCE_LIMIT), value);
                 this._lowerToleranceLimit = value; }
         }
         public int MinimumStartWeight // Type : signed integer 32 Bit
         {
             get { return _minimumStartWeight; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.MINIMUM_START_WEIGHT), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.MINIMUM_START_WEIGHT), value);
                 this._minimumStartWeight = value; }
         }
         public int EmptyWeight // Type : signed integer 32 Bit
         {
             get { return _emptyWeight; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.EMPTY_WEIGHT_TOLERANCE), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.EMPTY_WEIGHT_TOLERANCE), value);
                 this._emptyWeight = value; }
         }
         public int TareDelay // Type : unsigned integer 16 Bit
         {
             get { return _tareDelay; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.TARE_DELAY), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.TARE_DELAY), value);
                 this._tareDelay = value; }
         }
         public int CoarseFlowMonitoringTime // Type : unsigned integer 16 Bit
         {
             get { return _coarseFlowMonitoringTime; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.COARSE_FLOW_MONITORING_TIME), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.COARSE_FLOW_MONITORING_TIME), value);
                 this._coarseFlowMonitoringTime = value; }
         }
         public int CoarseFlowMonitoring  // Type : unsigned integer 32 Bit
         {
             get { return _coarseFlowMonitoring; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.COARSE_FLOW_MONITORING), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.COARSE_FLOW_MONITORING), value);
                 this._coarseFlowMonitoring = value; }
         }
         public int FineFlowMonitoring  // Type : unsigned integer 32 Bit
         {
             get { return _fineFlowMonitoring; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.FINE_FLOW_MONITORING), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.FINE_FLOW_MONITORING), value);
                 this._fineFlowMonitoring = value; }
         }
         public int FineFlowMonitoringTime // Type : unsigned integer 16 Bit
         {
             get { return _fineFlowMonitoringTime; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.FINE_FLOW_MONITORING_TIME), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.FINE_FLOW_MONITORING_TIME), value);
                 this._fineFlowMonitoringTime = value; }
         }
         public int DelayTimeAfterFineFlow  // Type : unsigned integer 8 Bit
@@ -546,13 +543,13 @@ namespace HBM.Weighing.API.Data
         public int SystematicDifference // Type : unsigned integer 32 Bit
         {
             get { return _systematicDifference; }
-            set { _connection.Write(this.getIndex(_connection.IDCommands.SYSTEMATIC_DIFFERENCE), value);
+            set { _connection.WriteArray(this.getIndex(_connection.IDCommands.SYSTEMATIC_DIFFERENCE), value);
                 this._systematicDifference = value; }
         }
         public int DownwardsDosing  // Type : unsigned integer 8 Bit
         {
             get { return _downwardsDosing; }
-            set { //_connection.Write(_connection.IDCommands.DOWNWARDS_DOSING, value);  // Downwards dosing only for modbus according to its name. 
+            set { //_connection.Write(_connection.IDCommands.DOWNWARDS_DOSING, value); 
                 this._downwardsDosing = value; }
         }
         public int ValveControl  // Type : unsigned integer 8 Bit

--- a/HBM.Weighing.API/Data/DataFiller.cs
+++ b/HBM.Weighing.API/Data/DataFiller.cs
@@ -207,7 +207,7 @@ namespace HBM.Weighing.API.Data
 
         public void UpdateFillerData(object sender, DataEventArgs e)
         {
-            if (e.DataDictionary[_connection.IDCommands.APPLICATION_MODE] == 2)
+            if (e.DataDictionary[_connection.IDCommands.APPLICATION_MODE] == 2 || e.DataDictionary[_connection.IDCommands.APPLICATION_MODE] == 3)  // If application mode = filler
             {
                 _maxDosingTime = Convert.ToInt32(e.DataDictionary[this.getIndex(_connection.IDCommands.MAXIMAL_DOSING_TIME)]);
                 _meanValueDosingResults = Convert.ToInt32(e.DataDictionary[this.getIndex(_connection.IDCommands.MEAN_VALUE_DOSING_RESULTS)]);

--- a/HBM.Weighing.API/Data/DataFillerExtended.cs
+++ b/HBM.Weighing.API/Data/DataFillerExtended.cs
@@ -233,7 +233,7 @@ namespace HBM.Weighing.API.Data
 
         public void UpdateFillerExtendedData(object sender, DataEventArgs e)
         {
-            if (e.DataDictionary[_connection.IDCommands.APPLICATION_MODE] == 2)
+            if (e.DataDictionary[_connection.IDCommands.APPLICATION_MODE] == 2 ||  e.DataDictionary[_connection.IDCommands.APPLICATION_MODE] == 3) // If application mode = filler
             {
                 this.UpdateFillerData(this, e);
                 /*

--- a/HBM.Weighing.API/Data/DataStandard.cs
+++ b/HBM.Weighing.API/Data/DataStandard.cs
@@ -115,9 +115,7 @@ namespace HBM.Weighing.API.Data
         private int _switchOnLevelLIV43;
         private int _switchOffLevelLIV44;
 
-        private INetConnection _connection;
-
-        private ushort[] _dataToWrite;
+        private INetConnection _connection;        
         #endregion
 
         #region constructor
@@ -127,9 +125,7 @@ namespace HBM.Weighing.API.Data
             _connection = Connection;
 
             _connection.UpdateDataClasses += UpdateStandardData;
-
-            _dataToWrite = new ushort[2];
-
+            
             _input1 = 0;
             _input2=0;
             _input3=0;
@@ -365,7 +361,6 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue1Input; }
             set
             {
-
                 _connection.Write(this.getIndex(_connection.IDCommands.SIGNAL_SOURCE_LIV12), value);
                 _limitValue1Input = value;
             }
@@ -384,10 +379,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue1ActivationLevelLowerBandLimit; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-               this._connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV13), _dataToWrite);
+                this._connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV13), value);
                 _limitValue1ActivationLevelLowerBandLimit = value;
             }
         }
@@ -396,10 +388,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue1HysteresisBandHeight; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_OFF_LEVEL_LIV14), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_OFF_LEVEL_LIV14), value);
                 _limitValue1HysteresisBandHeight = value;
             }
         }
@@ -426,10 +415,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue2ActivationLevelLowerBandLimit; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV23), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV23), value);
                 _limitValue2ActivationLevelLowerBandLimit = value;
             }
         }
@@ -438,10 +424,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue2HysteresisBandHeight; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.TARE_VALUE), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_OFF_LEVEL_LIV24), value);
                 _limitValue2HysteresisBandHeight = value;
             }
         }
@@ -468,10 +451,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue3ActivationLevelLowerBandLimit; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV33), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV33), value);
                 _limitValue3ActivationLevelLowerBandLimit = value;
             }
         }
@@ -480,10 +460,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue3HysteresisBandHeight; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_OFF_LEVEL_LIV34), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_OFF_LEVEL_LIV34), value);
                 _limitValue3HysteresisBandHeight = value;
             }
         }
@@ -510,10 +487,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue4ActivationLevelLowerBandLimit; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV43), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_ON_LEVEL_LIV43), value);
                 _limitValue4ActivationLevelLowerBandLimit = value;
             }
         }
@@ -522,10 +496,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitValue4HysteresisBandHeight; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_OFF_LEVEL_LIV44), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.SWITCH_OFF_LEVEL_LIV44), value);
                 _limitValue4HysteresisBandHeight = value;
             }
         }
@@ -534,10 +505,7 @@ namespace HBM.Weighing.API.Data
             get { return _calibrationWeight; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.LFT_SCALE_CALIBRATION_WEIGHT), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.LFT_SCALE_CALIBRATION_WEIGHT), value);
                 _calibrationWeight = value;
             }
         }
@@ -546,10 +514,7 @@ namespace HBM.Weighing.API.Data
             get { return _zeroLoad; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.LDW_DEAD_WEIGHT), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.LDW_DEAD_WEIGHT), value);
                 _zeroLoad = value;
             }
         }
@@ -558,10 +523,7 @@ namespace HBM.Weighing.API.Data
             get { return _nominalLoad; }
             set
             {
-                _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
-                _dataToWrite[1] = (ushort)(value & 0x0000ffff);
-
-                _connection.WriteArray(this.getIndex(_connection.IDCommands.LWT_NOMINAL_VALUE), _dataToWrite);
+                _connection.WriteArray(this.getIndex(_connection.IDCommands.LWT_NOMINAL_VALUE), value);
                 _nominalLoad = value;
             }
         }

--- a/HBM.Weighing.API/Data/ProcessData.cs
+++ b/HBM.Weighing.API/Data/ProcessData.cs
@@ -129,7 +129,7 @@ namespace HBM.Weighing.API
             if (_connection.ConnectionType.Equals("Modbus"))
                 _unit = Convert.ToInt32(e.DataDictionary["5/2/7"]);
             else           
-            _unit = (Convert.ToInt32(e.DataDictionary[_connection.IDCommands.UNIT_PREFIX_FIXED_PARAMETER]) & 0xFF0000) >> 16;
+                _unit = (Convert.ToInt32(e.DataDictionary[_connection.IDCommands.UNIT_PREFIX_FIXED_PARAMETER]) & 0xFF0000) >> 16;
             
             if (_connection.ConnectionType.Equals("Modbus"))
             {

--- a/HBM.Weighing.API/INetConnection.cs
+++ b/HBM.Weighing.API/INetConnection.cs
@@ -63,7 +63,7 @@ namespace HBM.Weighing.API
 
         Task<int> WriteAsync(ushort index, ushort commandParam);
 
-        void WriteArray(string index, ushort[] data);
+        void WriteArray(string index, int data);
                 
         Dictionary<string, int> AllData { get; }
 

--- a/HBM.Weighing.API/INetConnection.cs
+++ b/HBM.Weighing.API/INetConnection.cs
@@ -63,7 +63,7 @@ namespace HBM.Weighing.API
 
         Task<int> WriteAsync(ushort index, ushort commandParam);
 
-        void WriteArray(ushort index, ushort[] data);
+        void WriteArray(string index, ushort[] data);
                 
         Dictionary<string, int> AllData { get; }
 

--- a/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
@@ -592,9 +592,10 @@ namespace HBM.Weighing.API.WTX.Jet
             // GC.SuppressFinalize(this);
         }
 
-        public void WriteArray(string index, ushort[] data)
+        public void WriteArray(string index, int data)
         {
-            throw new NotImplementedException();
+            JValue value = new JValue(data);
+            SetData(index, value);
         }
 
         public Dictionary<string, JToken> getDataBuffer

--- a/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
@@ -592,7 +592,7 @@ namespace HBM.Weighing.API.WTX.Jet
             // GC.SuppressFinalize(this);
         }
 
-        public void WriteArray(ushort index, ushort[] data)
+        public void WriteArray(string index, ushort[] data)
         {
             throw new NotImplementedException();
         }

--- a/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
@@ -66,6 +66,7 @@ namespace HBM.Weighing.API.WTX.Modbus
         private ushort _startAdress;
 
         private ushort[] _data;
+        private ushort[] _dataToWrite;
 
         private Dictionary<string, int> _dataIntegerBuffer = new Dictionary<string, int>();
 
@@ -92,6 +93,8 @@ namespace HBM.Weighing.API.WTX.Modbus
             _commands = new ModbusCommands();
 
             this.CreateDictionary();
+
+            _dataToWrite = new ushort[2]{0,0};
 
             _numOfPoints = WTX_DEFAULT_DATAWORD_COUNT;
             _startAdress = WTX_DEFAULT_START_ADDRESS;
@@ -262,9 +265,12 @@ namespace HBM.Weighing.API.WTX.Modbus
             return this.command;
         }
 
-        public void WriteArray(string index, ushort[] data)
+        public void WriteArray(string index, int value)
         {
-            _master.WriteMultipleRegisters((ushort) Convert.ToInt32(index), data);
+            _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
+            _dataToWrite[1] = (ushort)(value & 0x0000ffff);
+ 
+            _master.WriteMultipleRegisters((ushort) Convert.ToInt32(index), _dataToWrite);
 
             BusActivityDetection?.Invoke(this, new LogEvent("Data(ushort array) have been written successfully to multiple registers"));
         }
@@ -374,10 +380,6 @@ namespace HBM.Weighing.API.WTX.Modbus
 
             // Standard data: Missing ID's
             /*
-                _limitStatus1 = (_data[8] & 0x1); ;
-                _limitStatus2 = ((_data[8] & 0x2) >> 1);
-                _limitStatus3 = ((_data[8] & 0x4) >> 2);
-                _limitStatus4 = ((_data[8] & 0x8) >> 3);
                 _weightMemDay = (_data[9]);
                 _weightMemMonth = (_data[10]);
                 _weightMemYear = (_data[11]);

--- a/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
@@ -262,9 +262,9 @@ namespace HBM.Weighing.API.WTX.Modbus
             return this.command;
         }
 
-        public void WriteArray(ushort index, ushort[] data)
+        public void WriteArray(string index, ushort[] data)
         {
-            _master.WriteMultipleRegisters(index, data);
+            _master.WriteMultipleRegisters((ushort) Convert.ToInt32(index), data);
 
             BusActivityDetection?.Invoke(this, new LogEvent("Data(ushort array) have been written successfully to multiple registers"));
         }
@@ -353,7 +353,7 @@ namespace HBM.Weighing.API.WTX.Modbus
                 _dataIntegerBuffer[IDCommands.APPLICATION_MODE] = _data[5] & 0x1;                      // application mode 
                 _dataIntegerBuffer[IDCommands.DECIMALS] = (_data[5] & 0x70) >> 4;                      // decimals
                 _dataIntegerBuffer[IDCommands.UNIT_PREFIX_FIXED_PARAMETER] = (_data[5] & 0x180) >> 7;  // unit
- 
+            
                 _dataIntegerBuffer[IDCommands.COARSE_FLOW_MONITORING] = _data[8] & 0x1;         //_coarseFlow
                 _dataIntegerBuffer[IDCommands.FINE_FLOW_MONITORING] = ((_data[8] & 0x2) >> 1);  // _fineFlow
 
@@ -371,8 +371,6 @@ namespace HBM.Weighing.API.WTX.Modbus
                 _dataIntegerBuffer[IDCommands.COARSE_FLOW_TIME] = _data[25];            // _currentCoarseFlowTime
                 _dataIntegerBuffer[IDCommands.FINE_FLOW_TIME] = _data[26];              // _currentFineFlowTime
                 _dataIntegerBuffer[IDCommands.RANGE_SELECTION_PARAMETER] = _data[27];   // _parameterSetProduct
-
-                _dataIntegerBuffer[IDCommands.LIMIT_VALUE] = _data[8];
 
             // Standard data: Missing ID's
             /*

--- a/HBM.Weighing.API/WTX/WTXJet.cs
+++ b/HBM.Weighing.API/WTX/WTXJet.cs
@@ -375,9 +375,19 @@ namespace HBM.Weighing.API.WTX
             throw new NotImplementedException();
         }
 
-        public override void SetOutput(object index, int value)
+        public void SetOutput(object index, int value)
         {
             _connection.Write(Convert.ToString(index),value);
+        }
+
+        public override void StopUpdate()
+        {
+            _connection.IncomingDataReceived -= this.OnData;   // Subscribe to the event. 
+        }
+
+        public override void RestartUpdate()
+        {
+            _connection.IncomingDataReceived += this.OnData;   // Subscribe to the event. 
         }
         #endregion
     }

--- a/HBM.Weighing.API/WTX/WTXModbus.cs
+++ b/HBM.Weighing.API/WTX/WTXModbus.cs
@@ -231,12 +231,12 @@ namespace HBM.Weighing.API.WTX
             get { return this._dataFiller; }
         }
 
-        public override void SetOutput(object index, int value)
+        public void SetOutput(object index, int value)
         {
-            _dataWritten[0] = (ushort)((value & 0xffff0000) >> 16);
-            _dataWritten[1] = (ushort)(value & 0x0000ffff);
+            //_dataWritten[0] = (ushort)((value & 0xffff0000) >> 16);
+            //_dataWritten[1] = (ushort)(value & 0x0000ffff);
 
-            this._connection.WriteArray(Convert.ToString(index), _dataWritten);
+            this._connection.WriteArray(Convert.ToString(index), value);
         }
         /*
         private void WriteOutputWordU08(int valueParam, ushort wordNumber)
@@ -334,7 +334,7 @@ namespace HBM.Weighing.API.WTX
         /*
         * This method stops the timer, for example in case for the calibration.
         */
-        public void StopTimer()
+        public override void StopUpdate()
         {
             _aTimer.Elapsed -= OnTimedEvent;
             _aTimer.Enabled = false;
@@ -344,7 +344,7 @@ namespace HBM.Weighing.API.WTX
         /*
          * This method restarts the timer, for example in case for the calibration.
          */
-        public void RestartTimer()
+        public override void RestartUpdate()
         {
             _aTimer.Elapsed += OnTimedEvent;
             _aTimer.Enabled = true;
@@ -498,7 +498,7 @@ namespace HBM.Weighing.API.WTX
         // This methods sets the value of the WTX to zero. 
         public override void MeasureZero()
         {
-            this.StopTimer();
+            this.StopUpdate();
 
             //todo: write reg 48, 0x7FFFFFFF
 
@@ -524,7 +524,7 @@ namespace HBM.Weighing.API.WTX
 
             this.WriteSync(0, 0x100);
 
-            this.RestartTimer();
+            this.RestartUpdate();
 
             this._isCalibrating = true;
 
@@ -564,7 +564,7 @@ namespace HBM.Weighing.API.WTX
             dPreload = preload * multiplierMv2D;
             dNominalLoad = dPreload + (capacity * multiplierMv2D);
                            
-            this.StopTimer();
+            this.StopUpdate();
 
             //write reg 48, DPreload;         
 
@@ -580,7 +580,7 @@ namespace HBM.Weighing.API.WTX
 
             this._isCalibrating = true;
 
-            this.RestartTimer();
+            this.RestartUpdate();
 
         }
 

--- a/Tests/JetbusTest/TestJetbusConnection.cs
+++ b/Tests/JetbusTest/TestJetbusConnection.cs
@@ -506,9 +506,9 @@ namespace HBM.Weighing.API.WTX.Jet
         }
 
 
-        public void WriteArray(string index, ushort[] data)
+        public void WriteArray(string index, int data)
         {
-            throw new NotImplementedException();
+            //throw new NotImplementedException();
         }
 
         public void SendMessage(string json)

--- a/Tests/JetbusTest/TestJetbusConnection.cs
+++ b/Tests/JetbusTest/TestJetbusConnection.cs
@@ -506,7 +506,7 @@ namespace HBM.Weighing.API.WTX.Jet
         }
 
 
-        public void WriteArray(ushort index, ushort[] data)
+        public void WriteArray(string index, ushort[] data)
         {
             throw new NotImplementedException();
         }

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -786,8 +786,9 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         }
 
-        public void WriteArray(ushort index, ushort[] data)
+        public void WriteArray(string index, ushort[] data)
         {
+            int _index = Convert.ToInt16(index);
 
             switch (this.behavior)
             {
@@ -802,7 +803,7 @@ namespace HBM.Weighing.API.WTX.Modbus
                     break;
 
                 case Behavior.WriteS32ArrayTestSuccess:
-                        this.wordNumberIndex = index;
+                        this.wordNumberIndex = _index;
                         this.arrayElement1 = data[0];
                         this.arrayElement2 = data[1];
                     break;
@@ -820,13 +821,13 @@ namespace HBM.Weighing.API.WTX.Modbus
 
                 case Behavior.CalibrationSuccess:
 
-                    if ((int)index == 48 || (int) index== 46)       // According to the index 48 (=wordnumber) the preload is written. 
+                    if ((int)_index == 48 || (int)_index == 46)       // According to the index 48 (=wordnumber) the preload is written. 
                     {
                         this.arrayElement1 = data[0];
                         this.arrayElement2 = data[1];
                     }
                     else
-                    if ((int)index == 50)       // According to the index 50 (=wordnumber) the nominal load is written. 
+                    if ((int)_index == 50)       // According to the index 50 (=wordnumber) the nominal load is written. 
                     {
                         this.arrayElement3 = data[0];
                         this.arrayElement4 = data[1];

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -193,6 +193,9 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private int numPoints;
 
+        private ushort[] _data;
+        private int _index;
+
         public LogEvent _logObj;
 
         public TestModbusTCPConnection(Behavior behavior,string ipAddress) 
@@ -209,6 +212,9 @@ namespace HBM.Weighing.API.WTX.Modbus
             this.behavior = behavior;
 
             this.numPoints = 6;
+
+             _data = new ushort[2];
+            _index = 0;
 
             for (int index = 0; index < _dataWTX.Length; index++)
                 _dataWTX[index] = 0x00;
@@ -786,15 +792,18 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         }
 
-        public void WriteArray(string index, ushort[] data)
+        public void WriteArray(string index, int value)
         {
-            int _index = Convert.ToInt16(index);
+            _data[0] = (ushort)((value & 0xffff0000) >> 16);
+            _data[1] = (ushort)(value & 0x0000ffff);
+
+            _index = Convert.ToInt16(index);
 
             switch (this.behavior)
             {
                 case Behavior.UpdateOutputTestSuccess:
-                        this.arrayElement1 = data[0];
-                        this.arrayElement2 = data[1];
+                        this.arrayElement1 = _data[0];
+                        this.arrayElement2 = _data[1];
                     break;
 
                 case Behavior.UpdateOutputTestFail:
@@ -804,8 +813,8 @@ namespace HBM.Weighing.API.WTX.Modbus
 
                 case Behavior.WriteS32ArrayTestSuccess:
                         this.wordNumberIndex = _index;
-                        this.arrayElement1 = data[0];
-                        this.arrayElement2 = data[1];
+                        this.arrayElement1 = _data[0];
+                        this.arrayElement2 = _data[1];
                     break;
 
                 case Behavior.WriteS32ArrayTestFail:
@@ -823,14 +832,14 @@ namespace HBM.Weighing.API.WTX.Modbus
 
                     if ((int)_index == 48 || (int)_index == 46)       // According to the index 48 (=wordnumber) the preload is written. 
                     {
-                        this.arrayElement1 = data[0];
-                        this.arrayElement2 = data[1];
+                        this.arrayElement1 = _data[0];
+                        this.arrayElement2 = _data[1];
                     }
                     else
                     if ((int)_index == 50)       // According to the index 50 (=wordnumber) the nominal load is written. 
                     {
-                        this.arrayElement3 = data[0];
-                        this.arrayElement4 = data[1];
+                        this.arrayElement3 = _data[0];
+                        this.arrayElement4 = _data[1];
                     }
                         break;
 
@@ -841,8 +850,8 @@ namespace HBM.Weighing.API.WTX.Modbus
                     break;
 
                 case Behavior.WriteArraySuccess:
-                    this.arrayElement1 = data[0];
-                    this.arrayElement2 = data[1];
+                    this.arrayElement1 = _data[0];
+                    this.arrayElement2 = _data[1];
 
                     break;
 
@@ -850,8 +859,8 @@ namespace HBM.Weighing.API.WTX.Modbus
 
                     _dataWTX[0] = 0;
                     _dataWTX[0] = 0; 
-                    this.arrayElement1 = data[0];
-                    this.arrayElement2 = data[1];
+                    this.arrayElement1 = _data[0];
+                    this.arrayElement2 = _data[1];
 
                     break;
 


### PR DESCRIPTION
Data classes : Writing to WTX, using method WriteArray(index,ushort[] data)
GUIsimple : Simpliy update method.
WTXModbus : Add simple constructor with one parameter(INetConnection).
Connection classes : Parameter type of 'index' to string.
BaseWtDevice (WtxModbus, WtxJet) : Adding methods for stopping and restarting the data update ("RestartUpdate()", "StopUpdate()").
CommandLine application : Description of values changed from "As an Integer" to "As an int/bool".
INetConnection method 'WriteArray' : Change of parameter type from 'ushort[] data' to 'int data' (conversion to ushort [ ] array in method WriteArray(..))
DataFiller, DataStandard : Using method WriteArray() to write signed Integer 32 Bit and 16 bit values.