### PR TITLE
Paths from ModbusCommand for dictionary ; Application mode to ModbusCommand ; List to ModbusCommands ; Naming of limit switches

### DIFF
--- a/HBM.Weighing.API/Data/DataFillerModbus.cs
+++ b/HBM.Weighing.API/Data/DataFillerModbus.cs
@@ -216,75 +216,75 @@ namespace HBM.Weighing.API.Data
 
         public void UpdateFillerData(object sender, DataEventArgs e)
         {
-            if (e.DataDictionary[_commands.Application_mode.PathIndex + Convert.ToInt32(_commands.Application_mode.IO).ToString() + _commands.Application_mode.BitLength.ToString() + _commands.Application_mode.BitIndex.ToString()] == 2 || e.DataDictionary[_commands.Application_mode.PathIndex + Convert.ToInt32(_commands.Application_mode.IO).ToString() + _commands.Application_mode.BitLength.ToString() + _commands.Application_mode.BitIndex.ToString()] == 3)  // If application mode = filler
+            if (e.DataDictionary[_commands.Application_mode.Path] == 2 || e.DataDictionary[_commands.Application_mode.Path] == 3)  // If application mode = filler
             {
                 // Via Modbus and Jetbus IDs: 
-                _maxDosingTime = Convert.ToInt32(e.DataDictionary[(_commands.Maximal_dosing_time.PathIndex + Convert.ToInt32(_commands.Maximal_dosing_time.IO).ToString() + _commands.Maximal_dosing_time.BitLength.ToString() + _commands.Maximal_dosing_time.BitIndex.ToString())]);
-                //_meanValueDosingResults = Convert.ToInt32(e.DataDictionary[(_commands.Mean_value_dosing_results)]);
-                //_standardDeviation = Convert.ToInt32(e.DataDictionary[(_commands.Standard_deviation)]);
-                _fineFlowCutOffPoint = Convert.ToInt32(e.DataDictionary[(_commands.Fine_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Fine_flow_cut_off_point.IO).ToString() + _commands.Fine_flow_cut_off_point.BitLength.ToString() + _commands.Fine_flow_cut_off_point.BitIndex.ToString())]);
-                _coarseFlowCutOffPoint = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Coarse_flow_cut_off_point.IO).ToString() + _commands.Coarse_flow_cut_off_point.BitLength.ToString() + _commands.Coarse_flow_cut_off_point.BitIndex.ToString())]);
+                _maxDosingTime = Convert.ToInt32(e.DataDictionary[(_commands.Maximal_dosing_time.Path)]);
+                //_meanValueDosingResults = Convert.ToInt32(e.DataDictionary[(_commands.Mean_value_dosing_results.Path)]);
+                //_standardDeviation = Convert.ToInt32(e.DataDictionary[(_commands.Standard_deviation.Path)]);
+                _fineFlowCutOffPoint = Convert.ToInt32(e.DataDictionary[(_commands.Fine_flow_cut_off_point.Path)]);
+                _coarseFlowCutOffPoint = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_cut_off_point.Path)]);
 
-                //_residualFlowTime = Convert.ToInt32(e.DataDictionary[(_commands.Residual_flow_time)]);
-                _minimumFineFlow = Convert.ToInt32(e.DataDictionary[(_commands.Minimum_fine_flow.PathIndex + Convert.ToInt32(_commands.Minimum_fine_flow.IO).ToString() + _commands.Minimum_fine_flow.BitLength.ToString() + _commands.Minimum_fine_flow.BitIndex.ToString())]);
-                _optimizationOfCutOffPoints = Convert.ToInt32(e.DataDictionary[(_commands.Optimization.PathIndex + Convert.ToInt32(_commands.Optimization.IO).ToString() + _commands.Optimization.BitLength.ToString() + _commands.Optimization.BitIndex.ToString())]);
-                _maximumDosingTime = Convert.ToInt32(e.DataDictionary[(_commands.Maximal_dosing_time.PathIndex + Convert.ToInt32(_commands.Maximal_dosing_time.IO).ToString() + _commands.Maximal_dosing_time.BitLength.ToString() + _commands.Maximal_dosing_time.BitIndex.ToString())]);
-                _coarseLockoutTime = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_time.PathIndex + Convert.ToInt32(_commands.Coarse_flow_time.IO).ToString() + _commands.Coarse_flow_time.BitLength.ToString() + _commands.Coarse_flow_time.BitIndex.ToString())]);
-                _fineLockoutTime = Convert.ToInt32(e.DataDictionary[(_commands.CurrentFineFlowTime.PathIndex + Convert.ToInt32(_commands.CurrentFineFlowTime.IO).ToString() + _commands.CurrentFineFlowTime.BitLength.ToString() + _commands.CurrentFineFlowTime.BitIndex.ToString())]);
-                _tareMode = Convert.ToInt32(e.DataDictionary[(_commands.Tare_mode.PathIndex + Convert.ToInt32(_commands.Tare_mode.IO).ToString() + _commands.Tare_mode.BitLength.ToString() + _commands.Tare_mode.BitIndex.ToString())]);
+                //_residualFlowTime = Convert.ToInt32(e.DataDictionary[(_commands.Residual_flow_time.Path)]);
+                _minimumFineFlow = Convert.ToInt32(e.DataDictionary[(_commands.Minimum_fine_flow.Path)]);
+                _optimizationOfCutOffPoints = Convert.ToInt32(e.DataDictionary[(_commands.Optimization.Path)]);
+                _maximumDosingTime = Convert.ToInt32(e.DataDictionary[(_commands.Maximal_dosing_time.Path)]);
+                _coarseLockoutTime = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_time.Path)]);
+                _fineLockoutTime = Convert.ToInt32(e.DataDictionary[(_commands.CurrentFineFlowTime.Path)]);
+                _tareMode = Convert.ToInt32(e.DataDictionary[(_commands.Tare_mode.Path)]);
 
-                _upperToleranceLimit = Convert.ToInt32(e.DataDictionary[(_commands.Upper_tolerance_limit.PathIndex + Convert.ToInt32(_commands.Upper_tolerance_limit.IO).ToString() + _commands.Upper_tolerance_limit.BitLength.ToString() + _commands.Upper_tolerance_limit.BitIndex.ToString())]);
-                _lowerToleranceLimit = Convert.ToInt32(e.DataDictionary[(_commands.Lower_tolerance_limit.PathIndex + Convert.ToInt32(_commands.Lower_tolerance_limit.IO).ToString() + _commands.Lower_tolerance_limit.BitLength.ToString() + _commands.Lower_tolerance_limit.BitIndex.ToString())]);
-                _minimumStartWeight = Convert.ToInt32(e.DataDictionary[(_commands.Minimum_start_weight.PathIndex + Convert.ToInt32(_commands.Minimum_start_weight.IO).ToString() + _commands.Minimum_start_weight.BitLength.ToString() + _commands.Minimum_start_weight.BitIndex.ToString())]);
-                //_emptyWeight = Convert.ToInt32(e.DataDictionary[(_commands.Empty_weight)]);
-                _tareDelay = Convert.ToInt32(e.DataDictionary[(_commands.Tare_delay.PathIndex + Convert.ToInt32(_commands.Tare_delay.IO).ToString() + _commands.Tare_delay.BitLength.ToString() + _commands.Tare_delay.BitIndex.ToString())]);
+                _upperToleranceLimit = Convert.ToInt32(e.DataDictionary[(_commands.Upper_tolerance_limit.Path)]);
+                _lowerToleranceLimit = Convert.ToInt32(e.DataDictionary[(_commands.Lower_tolerance_limit.Path)]);
+                _minimumStartWeight = Convert.ToInt32(e.DataDictionary[(_commands.Minimum_start_weight.Path)]);
+                //_emptyWeight = Convert.ToInt32(e.DataDictionary[(_commands.Empty_weight.Path)]);
+                _tareDelay = Convert.ToInt32(e.DataDictionary[(_commands.Tare_delay.Path)]);
 
-                _coarseFlowMonitoringTime = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_monitoring_time.IO).ToString() + _commands.Coarse_flow_monitoring_time.BitLength.ToString() + _commands.Coarse_flow_monitoring_time.BitIndex.ToString()]);
-                _coarseFlowMonitoring = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_monitoring.PathIndex + Convert.ToInt32(_commands.Coarse_flow_monitoring.IO).ToString() + _commands.Coarse_flow_monitoring.BitLength.ToString() + _commands.Coarse_flow_monitoring.BitIndex.ToString())]);
-                _fineFlowMonitoring = Convert.ToInt32(e.DataDictionary[(_commands.Fine_flow_monitoring.PathIndex + Convert.ToInt32(_commands.Fine_flow_monitoring.IO).ToString() + _commands.Fine_flow_monitoring.BitLength.ToString() + _commands.Fine_flow_monitoring.BitIndex.ToString())]);
-                _fineFlowMonitoringTime = Convert.ToInt32(e.DataDictionary[(_commands.Fine_flow_monitoring_time.PathIndex + Convert.ToInt32(_commands.Fine_flow_monitoring_time.IO).ToString() + _commands.Fine_flow_monitoring_time.BitLength.ToString() + _commands.Fine_flow_monitoring_time.BitIndex.ToString())]); ;
+                _coarseFlowMonitoringTime = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_monitoring_time.Path)]);
+                _coarseFlowMonitoring = Convert.ToInt32(e.DataDictionary[(_commands.Coarse_flow_monitoring.Path)]);
+                _fineFlowMonitoring = Convert.ToInt32(e.DataDictionary[(_commands.Fine_flow_monitoring.Path)]);
+                _fineFlowMonitoringTime = Convert.ToInt32(e.DataDictionary[(_commands.Fine_flow_monitoring_time.Path)]); ;
 
-                _systematicDifference = Convert.ToInt32(e.DataDictionary[(_commands.Systematic_difference.PathIndex + Convert.ToInt32(_commands.Systematic_difference.IO).ToString() + _commands.Systematic_difference.BitLength.ToString() + _commands.Systematic_difference.BitIndex.ToString())]);
-                _valveControl = Convert.ToInt32(e.DataDictionary[(_commands.Valve_control.PathIndex + Convert.ToInt32(_commands.Valve_control.IO).ToString() + _commands.Valve_control.BitLength.ToString() + _commands.Valve_control.BitIndex.ToString())]);
-                _emptyingMode = Convert.ToInt32(e.DataDictionary[(_commands.Emptying_mode.PathIndex + Convert.ToInt32(_commands.Emptying_mode.IO).ToString() + _commands.Emptying_mode.BitLength.ToString() + _commands.Emptying_mode.BitIndex.ToString())]);
-                _delayTimeAfterFineFlow = Convert.ToInt32(e.DataDictionary[(_commands.Delay_time_after_fine_flow.PathIndex + Convert.ToInt32(_commands.Delay_time_after_fine_flow.IO).ToString() + _commands.Delay_time_after_fine_flow.BitLength.ToString() + _commands.Delay_time_after_fine_flow.BitIndex.ToString())]);
-                _activationTimeAfterFineFlow = Convert.ToInt32(e.DataDictionary[(_commands.Activation_time_after_fine_flow.PathIndex + Convert.ToInt32(_commands.Activation_time_after_fine_flow.IO).ToString() + _commands.Activation_time_after_fine_flow.BitLength.ToString() + _commands.Activation_time_after_fine_flow.BitIndex.ToString())]);
+                _systematicDifference = Convert.ToInt32(e.DataDictionary[(_commands.Systematic_difference.Path)]);
+                _valveControl = Convert.ToInt32(e.DataDictionary[(_commands.Valve_control.Path)]);
+                _emptyingMode = Convert.ToInt32(e.DataDictionary[(_commands.Emptying_mode.Path)]);
+                _delayTimeAfterFineFlow = Convert.ToInt32(e.DataDictionary[(_commands.Delay_time_after_fine_flow.Path)]);
+                _activationTimeAfterFineFlow = Convert.ToInt32(e.DataDictionary[(_commands.Activation_time_after_fine_flow.Path)]);
 
-                _adcOverUnderload = Convert.ToInt16(e.DataDictionary[_commands.AdcOverUnderload.PathIndex + Convert.ToInt32(_commands.AdcOverUnderload.IO).ToString() + _commands.AdcOverUnderload.BitLength.ToString() + _commands.AdcOverUnderload.BitIndex.ToString()]);
-                _legalForTradeOperation = Convert.ToInt16(e.DataDictionary[_commands.LegalForTradeOperation.PathIndex + Convert.ToInt32(_commands.LegalForTradeOperation.IO).ToString() + _commands.LegalForTradeOperation.BitLength.ToString() + _commands.LegalForTradeOperation.BitIndex.ToString()]);
-                _statusInput1 = Convert.ToInt16(e.DataDictionary[_commands.StatusInput1.PathIndex + Convert.ToInt32(_commands.StatusInput1.IO).ToString() + _commands.StatusInput1.BitLength.ToString() + _commands.StatusInput1.BitIndex.ToString()]);
-                _generalScaleError = Convert.ToInt16(e.DataDictionary[_commands.GeneralScaleError.PathIndex + Convert.ToInt32(_commands.GeneralScaleError.IO).ToString() + _commands.GeneralScaleError.BitLength.ToString() + _commands.GeneralScaleError.BitIndex.ToString()]);
+                _adcOverUnderload = Convert.ToInt16(e.DataDictionary[_commands.AdcOverUnderload.Path]);
+                _legalForTradeOperation = Convert.ToInt16(e.DataDictionary[_commands.LegalForTradeOperation.Path]);
+                _statusInput1 = Convert.ToInt16(e.DataDictionary[_commands.StatusInput1.Path]);
+                _generalScaleError = Convert.ToInt16(e.DataDictionary[_commands.GeneralScaleError.Path]);
 
-                _coarseFlow = Convert.ToInt16(e.DataDictionary[_commands.CoarseFlow.PathIndex + Convert.ToInt32(_commands.CoarseFlow.IO).ToString() + _commands.CoarseFlow.BitLength.ToString() + _commands.CoarseFlow.BitIndex.ToString()]);
-                _fineFlow = Convert.ToInt16(e.DataDictionary[_commands.FineFlow.PathIndex + Convert.ToInt32(_commands.FineFlow.IO).ToString() + _commands.FineFlow.BitLength.ToString() + _commands.FineFlow.BitIndex.ToString()]);
-                _ready = Convert.ToInt16(e.DataDictionary[_commands.Ready.PathIndex + Convert.ToInt32(_commands.Ready.IO).ToString() + _commands.Ready.BitLength.ToString() + _commands.Ready.BitIndex.ToString()]);
-                _reDosing = Convert.ToInt16(e.DataDictionary[_commands.ReDosing.PathIndex + Convert.ToInt32(_commands.ReDosing.IO).ToString() + _commands.ReDosing.BitLength.ToString() + _commands.ReDosing.BitIndex.ToString()]);
+                _coarseFlow = Convert.ToInt16(e.DataDictionary[_commands.CoarseFlow.Path]);
+                _fineFlow = Convert.ToInt16(e.DataDictionary[_commands.FineFlow.Path]);
+                _ready = Convert.ToInt16(e.DataDictionary[_commands.Ready.Path]);
+                _reDosing = Convert.ToInt16(e.DataDictionary[_commands.ReDosing.Path]);
 
-                _emptying = Convert.ToInt16(e.DataDictionary[_commands.Emptying.PathIndex + Convert.ToInt32(_commands.Emptying.IO).ToString() + _commands.Emptying.BitLength.ToString() + _commands.Emptying.BitIndex.ToString()]);
-                _flowError = Convert.ToInt16(e.DataDictionary[_commands.FlowError.PathIndex + Convert.ToInt32(_commands.FlowError.IO).ToString() + _commands.FlowError.BitLength.ToString() + _commands.FlowError.BitIndex.ToString()]);
-                _alarm = Convert.ToInt16(e.DataDictionary[_commands.Alarm.PathIndex + Convert.ToInt32(_commands.Alarm.IO).ToString() + _commands.Alarm.BitLength.ToString() + _commands.Alarm.BitIndex.ToString()]);
-                _toleranceErrorPlus = Convert.ToInt16(e.DataDictionary[_commands.ToleranceErrorPlus.PathIndex + Convert.ToInt32(_commands.ToleranceErrorPlus.IO).ToString() + _commands.ToleranceErrorPlus.BitLength.ToString() + _commands.ToleranceErrorPlus.BitIndex.ToString()]);
+                _emptying = Convert.ToInt16(e.DataDictionary[_commands.Emptying.Path]);
+                _flowError = Convert.ToInt16(e.DataDictionary[_commands.FlowError.Path]);
+                _alarm = Convert.ToInt16(e.DataDictionary[_commands.Alarm.Path]);
+                _toleranceErrorPlus = Convert.ToInt16(e.DataDictionary[_commands.ToleranceErrorPlus.Path]);
 
-                _toleranceErrorMinus = Convert.ToInt16(e.DataDictionary[_commands.ToleranceErrorMinus.PathIndex + Convert.ToInt32(_commands.ToleranceErrorMinus.IO).ToString() + _commands.ToleranceErrorMinus.BitLength.ToString() + _commands.ToleranceErrorMinus.BitIndex.ToString()]);
-                _currentDosingTime = Convert.ToInt16(e.DataDictionary[_commands.Dosing_time.PathIndex + Convert.ToInt32(_commands.Dosing_time.IO).ToString() + _commands.Dosing_time.BitLength.ToString() + _commands.Dosing_time.BitIndex.ToString()]);
-                _currentCoarseFlowTime = Convert.ToInt16(e.DataDictionary[_commands.Coarse_flow_time.PathIndex + Convert.ToInt32(_commands.Coarse_flow_time.IO).ToString() + _commands.Coarse_flow_time.BitLength.ToString() + _commands.Coarse_flow_time.BitIndex.ToString()]);
-                _currentFineFlowTime = Convert.ToInt16(e.DataDictionary[_commands.CurrentFineFlowTime.PathIndex + Convert.ToInt32(_commands.CurrentFineFlowTime.IO).ToString() + _commands.CurrentFineFlowTime.BitLength.ToString() + _commands.CurrentFineFlowTime.BitIndex.ToString()]);
+                _toleranceErrorMinus = Convert.ToInt16(e.DataDictionary[_commands.ToleranceErrorMinus.Path]);
+                _currentDosingTime = Convert.ToInt16(e.DataDictionary[_commands.Dosing_time.Path]);
+                _currentCoarseFlowTime = Convert.ToInt16(e.DataDictionary[_commands.Coarse_flow_time.Path]);
+                _currentFineFlowTime = Convert.ToInt16(e.DataDictionary[_commands.CurrentFineFlowTime.Path]);
 
-                _parameterSetProduct = Convert.ToInt16(e.DataDictionary[_commands.ParameterSetProduct.PathIndex + Convert.ToInt32(_commands.ParameterSetProduct.IO).ToString() + _commands.ParameterSetProduct.BitLength.ToString() + _commands.ParameterSetProduct.BitIndex.ToString()]);
-                _downwardsDosing = Convert.ToInt16(e.DataDictionary[_commands.DownwardsDosing.PathIndex + Convert.ToInt32(_commands.DownwardsDosing.IO).ToString() + _commands.DownwardsDosing.BitLength.ToString() + _commands.DownwardsDosing.BitIndex.ToString()]);
-                _totalWeight = Convert.ToInt32(e.DataDictionary[_commands.TotalWeight.PathIndex + Convert.ToInt32(_commands.TotalWeight.IO).ToString() + _commands.TotalWeight.BitLength.ToString() + _commands.TotalWeight.BitIndex.ToString()]);
+                _parameterSetProduct = Convert.ToInt16(e.DataDictionary[_commands.ParameterSetProduct.Path]);
+                _downwardsDosing = Convert.ToInt16(e.DataDictionary[_commands.DownwardsDosing.Path]);
+                _totalWeight = Convert.ToInt32(e.DataDictionary[_commands.TotalWeight.Path]);
 
-                //_targetFillingWeight = Convert.ToInt32(e.DataDictionary[_commands.TargetFillingWeight.PathIndex + Convert.ToInt32(_commands.TargetFillingWeight.IO).ToString() + _commands.TargetFillingWeight.BitLength.ToString() + _commands.TargetFillingWeight.BitIndex.ToString()]);
-                _coarseFlowCutOffPointSet = Convert.ToInt32(e.DataDictionary[_commands.Coarse_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Coarse_flow_cut_off_point.IO).ToString() + _commands.Coarse_flow_cut_off_point.BitLength.ToString() + _commands.Coarse_flow_cut_off_point.BitIndex.ToString()]);
-                _fineFlowCutOffPointSet = Convert.ToInt32(e.DataDictionary[_commands.Fine_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Fine_flow_cut_off_point.IO).ToString() + _commands.Fine_flow_cut_off_point.BitLength.ToString() + _commands.Fine_flow_cut_off_point.BitIndex.ToString()]);
-                _startWithFineFlow = Convert.ToInt32(e.DataDictionary[_commands.Run_start_dosing.PathIndex + Convert.ToInt32(_commands.Run_start_dosing.IO).ToString() + _commands.Run_start_dosing.BitLength.ToString() + _commands.Run_start_dosing.BitIndex.ToString()]);  // Command 'Run_start_dosing' right? 
+                //_targetFillingWeight = Convert.ToInt32(e.DataDictionary[_commands.TargetFillingWeight.Path]);
+                _coarseFlowCutOffPointSet = Convert.ToInt32(e.DataDictionary[_commands.Coarse_flow_cut_off_point.Path]);
+                _fineFlowCutOffPointSet = Convert.ToInt32(e.DataDictionary[_commands.Fine_flow_cut_off_point.Path]);
+                _startWithFineFlow = Convert.ToInt32(e.DataDictionary[_commands.Run_start_dosing.Path]);  // Command 'Run_start_dosing' right
 
-                _weightMemoryDay = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemDay_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemDay_ID.IO).ToString() + _commands.ReadWeightMemDay_ID.BitLength.ToString() + _commands.ReadWeightMemDay_ID.BitIndex.ToString()]);
-                _weightMemoryMonth = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemMonth_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemMonth_ID.IO).ToString() + _commands.ReadWeightMemMonth_ID.BitLength.ToString() + _commands.ReadWeightMemMonth_ID.BitIndex.ToString()]);
-                _weightMemoryYear = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemYear_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemYear_ID.IO).ToString() + _commands.ReadWeightMemYear_ID.BitLength.ToString() + _commands.ReadWeightMemYear_ID.BitIndex.ToString()]);
-                _weightMemorySeqNumber = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemSeqNumber_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemSeqNumber_ID.IO).ToString() + _commands.ReadWeightMemSeqNumber_ID.BitLength.ToString() + _commands.ReadWeightMemSeqNumber_ID.BitIndex.ToString()]);
-                _weightMemoryGross = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemGross_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemGross_ID.IO).ToString() + _commands.ReadWeightMemGross_ID.BitLength.ToString() + _commands.ReadWeightMemGross_ID.BitIndex.ToString()]);
-                _weightMemoryNet = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemNet_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemNet_ID.IO).ToString() + _commands.ReadWeightMemNet_ID.BitLength.ToString() + _commands.ReadWeightMemNet_ID.BitIndex.ToString()]);
+                _weightMemoryDay = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemDay_ID.Path]);
+                _weightMemoryMonth = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemMonth_ID.Path]);
+                _weightMemoryYear = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemYear_ID.Path]);
+                _weightMemorySeqNumber = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemSeqNumber_ID.Path]);
+                _weightMemoryGross = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemGross_ID.Path]);
+                _weightMemoryNet = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemNet_ID.Path]);
             }
         }
         #endregion
@@ -431,7 +431,7 @@ namespace HBM.Weighing.API.Data
             get { return _residualFlowTime; }
             set
             {
-                _connection.WriteArray(_commands.Residual_flow_time.PathIndex, value);
+                _connection.WriteArray(_commands.Residual_flow_time.Register, value);
                 this._residualFlowTime = value;
             }
         }
@@ -440,7 +440,7 @@ namespace HBM.Weighing.API.Data
             get { return _targetFillingWeight; }
             set
             {
-                _connection.WriteArray(_commands.Reference_value_dosing.PathIndex, value);
+                _connection.WriteArray(_commands.Reference_value_dosing.Register, value);
                 this._targetFillingWeight = value;
             }
         }
@@ -449,7 +449,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseFlowCutOffPointSet; }
             set
             {
-                _connection.WriteArray(_commands.Coarse_flow_cut_off_point.PathIndex, value);
+                _connection.WriteArray(_commands.Coarse_flow_cut_off_point.Register, value);
                 this._coarseFlowCutOffPointSet = value;
             }
         }
@@ -458,7 +458,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineFlowCutOffPointSet; }
             set
             {
-                _connection.WriteArray(_commands.Fine_flow_cut_off_point.PathIndex, value);
+                _connection.WriteArray(_commands.Fine_flow_cut_off_point.Register, value);
                 this._fineFlowCutOffPointSet = value;
             }
         }
@@ -467,7 +467,7 @@ namespace HBM.Weighing.API.Data
             get { return _minimumFineFlow; }
             set
             {
-                _connection.WriteArray(_commands.Minimum_fine_flow.PathIndex, value);
+                _connection.WriteArray(_commands.Minimum_fine_flow.Register, value);
                 this._minimumFineFlow = value;
             }
         }
@@ -476,7 +476,7 @@ namespace HBM.Weighing.API.Data
             get { return _optimizationOfCutOffPoints; }
             set
             {
-                _connection.Write(_commands.Optimization.PathIndex, value);
+                _connection.Write(_commands.Optimization.Register, value);
                 this._optimizationOfCutOffPoints = value;
             }
         }
@@ -485,7 +485,7 @@ namespace HBM.Weighing.API.Data
             get { return _maximumDosingTime; }
             set
             {
-                _connection.WriteArray(_commands.Maximal_dosing_time.PathIndex, value);
+                _connection.WriteArray(_commands.Maximal_dosing_time.Register, value);
                 this._maximumDosingTime = value;
             }
         }
@@ -494,7 +494,7 @@ namespace HBM.Weighing.API.Data
             get { return _startWithFineFlow; }
             set
             {
-                _connection.WriteArray(_commands.Run_start_dosing.PathIndex, value);
+                _connection.WriteArray(_commands.Run_start_dosing.Register, value);
                 this._startWithFineFlow = value;
             }
         }
@@ -503,7 +503,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseLockoutTime; }
             set
             {
-                _connection.WriteArray(_commands.Lockout_time_coarse_flow.PathIndex, value);
+                _connection.WriteArray(_commands.Lockout_time_coarse_flow.Register, value);
                 this._coarseLockoutTime = value;
             }
         }
@@ -512,7 +512,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineLockoutTime; }
             set
             {
-                _connection.WriteArray(_commands.Lockout_time_fine_flow.PathIndex, value);
+                _connection.WriteArray(_commands.Lockout_time_fine_flow.Register, value);
                 this._fineLockoutTime = value;
             }
         }
@@ -521,7 +521,7 @@ namespace HBM.Weighing.API.Data
             get { return _tareMode; }
             set
             {
-                _connection.Write(_commands.Tare_mode.PathIndex, value);
+                _connection.Write(_commands.Tare_mode.Register, value);
                 this._tareMode = value;
             }
         }
@@ -530,7 +530,7 @@ namespace HBM.Weighing.API.Data
             get { return _upperToleranceLimit; }
             set
             {
-                _connection.WriteArray(_commands.Upper_tolerance_limit.PathIndex, value);
+                _connection.WriteArray(_commands.Upper_tolerance_limit.Register, value);
                 this._upperToleranceLimit = value;
             }
         }
@@ -539,7 +539,7 @@ namespace HBM.Weighing.API.Data
             get { return _lowerToleranceLimit; }
             set
             {
-                _connection.WriteArray(_commands.Lower_tolerance_limit.PathIndex, value);
+                _connection.WriteArray(_commands.Lower_tolerance_limit.Register, value);
                 this._lowerToleranceLimit = value;
             }
         }
@@ -548,7 +548,7 @@ namespace HBM.Weighing.API.Data
             get { return _minimumStartWeight; }
             set
             {
-                _connection.WriteArray(_commands.Minimum_start_weight.PathIndex, value);
+                _connection.WriteArray(_commands.Minimum_start_weight.Register, value);
                 this._minimumStartWeight = value;
             }
         }
@@ -557,7 +557,7 @@ namespace HBM.Weighing.API.Data
             get { return _emptyWeight; }
             set
             {
-                _connection.WriteArray(_commands.Empty_weight.PathIndex, value);
+                _connection.WriteArray(_commands.Empty_weight.Register, value);
                 this._emptyWeight = value;
             }
         }
@@ -566,7 +566,7 @@ namespace HBM.Weighing.API.Data
             get { return _tareDelay; }
             set
             {
-                _connection.WriteArray(_commands.Tare_delay.PathIndex, value);
+                _connection.WriteArray(_commands.Tare_delay.Register, value);
                 this._tareDelay = value;
             }
         }
@@ -575,7 +575,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseFlowMonitoringTime; }
             set
             {
-                _connection.WriteArray(_commands.Coarse_flow_monitoring_time.PathIndex, value);
+                _connection.WriteArray(_commands.Coarse_flow_monitoring_time.Register, value);
                 this._coarseFlowMonitoringTime = value;
             }
         }
@@ -584,7 +584,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseFlowMonitoring; }
             set
             {
-                _connection.WriteArray(_commands.Coarse_flow_monitoring.PathIndex, value);
+                _connection.WriteArray(_commands.Coarse_flow_monitoring.Register, value);
                 this._coarseFlowMonitoring = value;
             }
         }
@@ -593,7 +593,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineFlowMonitoring; }
             set
             {
-                _connection.WriteArray(_commands.Fine_flow_monitoring.PathIndex, value);
+                _connection.WriteArray(_commands.Fine_flow_monitoring.Register, value);
                 this._fineFlowMonitoring = value;
             }
         }
@@ -602,7 +602,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineFlowMonitoringTime; }
             set
             {
-                _connection.WriteArray(_commands.Fine_flow_monitoring_time.PathIndex, value);
+                _connection.WriteArray(_commands.Fine_flow_monitoring_time.Register, value);
                 this._fineFlowMonitoringTime = value;
             }
         }
@@ -629,7 +629,7 @@ namespace HBM.Weighing.API.Data
             get { return _systematicDifference; }
             set
             {
-                _connection.WriteArray(_commands.Systematic_difference.PathIndex, value);
+                _connection.WriteArray(_commands.Systematic_difference.Register, value);
                 this._systematicDifference = value;
             }
         }
@@ -637,7 +637,7 @@ namespace HBM.Weighing.API.Data
         {
             get { return _downwardsDosing; }
             set
-            { //_connection.Write(_connection.IDCommands.DOWNWARDS_DOSING.PathIndex, value); 
+            { //_connection.Write(_connection.IDCommands.DOWNWARDS_DOSING.Register, value); 
                 this._downwardsDosing = value;
             }
         }
@@ -646,7 +646,7 @@ namespace HBM.Weighing.API.Data
             get { return _valveControl; }
             set
             {
-                _connection.Write(_commands.Valve_control.PathIndex, value);
+                _connection.Write(_commands.Valve_control.Register, value);
                 this._valveControl = value;
             }
         }
@@ -656,7 +656,7 @@ namespace HBM.Weighing.API.Data
             get { return _emptyingMode; }
             set
             {
-                _connection.Write(_commands.Emptying_mode.PathIndex, value);
+                _connection.Write(_commands.Emptying_mode.Register, value);
                 this._emptyingMode = value;
             }
         }

--- a/HBM.Weighing.API/Data/DataStandardJet.cs
+++ b/HBM.Weighing.API/Data/DataStandardJet.cs
@@ -230,27 +230,25 @@ namespace HBM.Weighing.API.Data
 
             if (e.DataDictionary[_commands.Application_mode.PathIndex] == 0 || e.DataDictionary[_commands.Application_mode.PathIndex] == 1)  // If application mode is in standard mode
             {
-                /*
-                _limitValueMonitoringLIV11 = e.DataDictionary[_commands.Limit_value_monitoring_liv11.PathIndex];
-                _signalSourceLIV12   = e.DataDictionary[_commands.Signal_source_liv12.PathIndex];
-                _switchOnLevelLIV13  = e.DataDictionary[_commands.Switch_on_level_liv13.PathIndex];
-                _switchOffLevelLIV14 = e.DataDictionary[_commands.Switch_off_level_liv14.PathIndex];
+                _limitSwitch1Source = e.DataDictionary[_commands.Limit_value_monitoring_liv11.PathIndex];
+                _limitSwitch1Mode = e.DataDictionary[_commands.Signal_source_liv12.PathIndex];
+                _limitSwitch1ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv13.PathIndex];
+                _limitSwitch1HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv14.PathIndex];
 
-                _limitValueMonitoringLIV21 = e.DataDictionary[_commands.Limit_value_monitoring_liv21.PathIndex];
-                _signalSourceLIV22   = e.DataDictionary[_commands.Signal_source_liv22.PathIndex];
-                _switchOnLevelLIV23  = e.DataDictionary[_commands.Switch_on_level_liv23.PathIndex];
-                _switchOffLevelLIV24 = e.DataDictionary[_commands.Switch_off_level_liv24.PathIndex];
+                _limitSwitch2Source = e.DataDictionary[_commands.Limit_value_monitoring_liv21.PathIndex];
+                _limitSwitch2Mode = e.DataDictionary[_commands.Signal_source_liv22.PathIndex];
+                _limitSwitch2ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv23.PathIndex];
+                _limitSwitch2HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv24.PathIndex];
 
-                _limitValueMonitoringLIV31 = e.DataDictionary[_commands.Limit_value_monitoring_liv31.PathIndex];
-                _signalSourceLIV32   = e.DataDictionary[_commands.Signal_source_liv32.PathIndex];
-                _switchOnLevelLIV33  = e.DataDictionary[_commands.Switch_on_level_liv33.PathIndex];
-                _switchOffLevelLIV34 = e.DataDictionary[_commands.Switch_off_level_liv34.PathIndex];
+                _limitSwitch3Source = e.DataDictionary[_commands.Limit_value_monitoring_liv31.PathIndex];
+                _limitSwitch3Mode = e.DataDictionary[_commands.Signal_source_liv32.PathIndex];
+                _limitSwitch3ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv33.PathIndex];
+                _limitSwitch3HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv34.PathIndex];
 
-                _limitValueMonitoringLIV41 = e.DataDictionary[_commands.Limit_value_monitoring_liv41.PathIndex];
-                _signalSourceLIV42   = e.DataDictionary[_commands.Signal_source_liv42.PathIndex];
-                _switchOnLevelLIV43  = e.DataDictionary[_commands.Switch_on_level_liv43.PathIndex];
-                _switchOffLevelLIV44 = e.DataDictionary[_commands.Switch_off_level_liv44.PathIndex];
-                */
+                _limitSwitch4Source = e.DataDictionary[_commands.Limit_value_monitoring_liv41.PathIndex];
+                _limitSwitch4Mode = e.DataDictionary[_commands.Signal_source_liv42.PathIndex];
+                _limitSwitch4ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv43.PathIndex];
+                _limitSwitch4HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv44.PathIndex];
             }
         }
         #endregion

--- a/HBM.Weighing.API/Data/DataStandardModbus.cs
+++ b/HBM.Weighing.API/Data/DataStandardModbus.cs
@@ -74,11 +74,6 @@ namespace HBM.Weighing.API.Data
         private int _weightMemoryGross;
         private int _weightMemoryNet;
 
-        // Jetbus only:
-
-        private int _weight_storage;
-        private int _mode_weight_storage;
-
         // Output words: 
 
         private int _limitSwitch1Input;
@@ -135,10 +130,7 @@ namespace HBM.Weighing.API.Data
             _weightMemoryYear = 0;
             _weightMemorySeqNumber = 0;
             _weightMemoryGross = 0;
-            _weightMemoryNet = 0;
-
-            _weight_storage = 0;
-            _mode_weight_storage = 0;
+            _weightMemoryNet = 0;;
 
             _limitSwitch1Input = 0;
             _limitSwitch1Mode = 0;
@@ -169,52 +161,49 @@ namespace HBM.Weighing.API.Data
 
         public void UpdateStandardData(object sender, DataEventArgs e)
         {
-            _input1 = (e.DataDictionary[_commands.Status_digital_input_1.PathIndex + Convert.ToInt32(_commands.Status_digital_input_1.IO).ToString() + _commands.Status_digital_input_1.BitLength.ToString() + _commands.Status_digital_input_1.BitIndex.ToString()] & 0x1);
-            _input2 = (e.DataDictionary[_commands.Status_digital_input_2.PathIndex + Convert.ToInt32(_commands.Status_digital_input_2.IO).ToString() + _commands.Status_digital_input_2.BitLength.ToString() + _commands.Status_digital_input_2.BitIndex.ToString()] & 0x2) >> 1;
-            _input3 = (e.DataDictionary[_commands.Status_digital_input_3.PathIndex + Convert.ToInt32(_commands.Status_digital_input_3.IO).ToString() + _commands.Status_digital_input_3.BitLength.ToString() + _commands.Status_digital_input_3.BitIndex.ToString()] & 0x4) >> 2;
-            _input4 = (e.DataDictionary[_commands.Status_digital_input_4.PathIndex + Convert.ToInt32(_commands.Status_digital_input_4.IO).ToString() + _commands.Status_digital_input_4.BitLength.ToString() + _commands.Status_digital_input_4.BitIndex.ToString()] & 0x8) >> 3;
+            _input1 = (e.DataDictionary[_commands.Status_digital_input_1.Path] & 0x1);
+            _input2 = (e.DataDictionary[_commands.Status_digital_input_2.Path] & 0x2) >> 1;
+            _input3 = (e.DataDictionary[_commands.Status_digital_input_3.Path] & 0x4) >> 2;
+            _input4 = (e.DataDictionary[_commands.Status_digital_input_4.Path] & 0x8) >> 3;
 
-            _output1 = e.DataDictionary [_commands.Status_digital_output_1.PathIndex + Convert.ToInt32(_commands.Status_digital_output_1.IO).ToString() + _commands.Status_digital_output_1.BitLength.ToString() + _commands.Status_digital_output_1.BitIndex.ToString()] & 0x1;
-            _output2 = (e.DataDictionary[_commands.Status_digital_output_2.PathIndex + Convert.ToInt32(_commands.Status_digital_output_2.IO).ToString() + _commands.Status_digital_output_2.BitLength.ToString() + _commands.Status_digital_output_2.BitIndex.ToString()] & 0x2) >> 1;
-            _output3 = (e.DataDictionary[_commands.Status_digital_output_3.PathIndex + Convert.ToInt32(_commands.Status_digital_output_3.IO).ToString() + _commands.Status_digital_output_3.BitLength.ToString() + _commands.Status_digital_output_3.BitIndex.ToString()] & 0x4) >> 2;
-            _output4 = (e.DataDictionary[_commands.Status_digital_output_4.PathIndex + Convert.ToInt32(_commands.Status_digital_output_4.IO).ToString() + _commands.Status_digital_output_4.BitLength.ToString() + _commands.Status_digital_output_4.BitIndex.ToString()] & 0x8) >> 3;
+            _output1 = e.DataDictionary [_commands.Status_digital_output_1.Path] & 0x1;
+            _output2 = (e.DataDictionary[_commands.Status_digital_output_2.Path] & 0x2) >> 1;
+            _output3 = (e.DataDictionary[_commands.Status_digital_output_3.Path] & 0x4) >> 2;
+            _output4 = (e.DataDictionary[_commands.Status_digital_output_4.Path] & 0x8) >> 3;
 
-            _limitStatus1 = (e.DataDictionary[_commands.Limit_value.PathIndex + Convert.ToInt32(_commands.Limit_value.IO).ToString() + _commands.Limit_value.BitLength.ToString() + _commands.Limit_value.BitIndex.ToString()] & 0x1);
-            _limitStatus2 = (e.DataDictionary[_commands.Limit_value.PathIndex + Convert.ToInt32(_commands.Limit_value.IO).ToString() + _commands.Limit_value.BitLength.ToString() + _commands.Limit_value.BitIndex.ToString()] & 0x2) >> 1;
-            _limitStatus3 = (e.DataDictionary[_commands.Limit_value.PathIndex + Convert.ToInt32(_commands.Limit_value.IO).ToString() + _commands.Limit_value.BitLength.ToString() + _commands.Limit_value.BitIndex.ToString()] & 0x4) >> 2;
-            _limitStatus4 = (e.DataDictionary[_commands.Limit_value.PathIndex + Convert.ToInt32(_commands.Limit_value.IO).ToString() + _commands.Limit_value.BitLength.ToString() + _commands.Limit_value.BitIndex.ToString()] & 0x8) >> 3;
+            _limitStatus1 = (e.DataDictionary[_commands.Limit_value.Path] & 0x1);
+            _limitStatus2 = (e.DataDictionary[_commands.Limit_value.Path] & 0x2) >> 1;
+            _limitStatus3 = (e.DataDictionary[_commands.Limit_value.Path] & 0x4) >> 2;
+            _limitStatus4 = (e.DataDictionary[_commands.Limit_value.Path] & 0x8) >> 3;
 
-            _weightMemoryDay = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemDay_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemDay_ID.IO).ToString() + _commands.ReadWeightMemDay_ID.BitLength.ToString() + _commands.ReadWeightMemDay_ID.BitIndex.ToString()]);
-            _weightMemoryMonth = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemMonth_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemMonth_ID.IO).ToString() + _commands.ReadWeightMemMonth_ID.BitLength.ToString() + _commands.ReadWeightMemMonth_ID.BitIndex.ToString()]);
-            _weightMemoryYear = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemYear_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemYear_ID.IO).ToString() + _commands.ReadWeightMemYear_ID.BitLength.ToString() + _commands.ReadWeightMemYear_ID.BitIndex.ToString()]);
-            _weightMemorySeqNumber = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemSeqNumber_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemSeqNumber_ID.IO).ToString() + _commands.ReadWeightMemSeqNumber_ID.BitLength.ToString() + _commands.ReadWeightMemSeqNumber_ID.BitIndex.ToString()]);
-            _weightMemoryGross = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemGross_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemGross_ID.IO).ToString() + _commands.ReadWeightMemGross_ID.BitLength.ToString() + _commands.ReadWeightMemGross_ID.BitIndex.ToString()]);
-            _weightMemoryNet = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemNet_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemNet_ID.IO).ToString() + _commands.ReadWeightMemNet_ID.BitLength.ToString() + _commands.ReadWeightMemNet_ID.BitIndex.ToString()]);
+            _weightMemoryDay = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemDay_ID.Path]);
+            _weightMemoryMonth = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemMonth_ID.Path]);
+            _weightMemoryYear = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemYear_ID.Path]);
+            _weightMemorySeqNumber = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemSeqNumber_ID.Path]);
+            _weightMemoryGross = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemGross_ID.Path]);
+            _weightMemoryNet = Convert.ToInt16(e.DataDictionary[_commands.ReadWeightMemNet_ID.Path]);
 
-            if (e.DataDictionary[_commands.Application_mode.PathIndex + Convert.ToInt32(_commands.Application_mode.IO).ToString() + _commands.Application_mode.BitLength.ToString() + _commands.Application_mode.BitIndex.ToString()] == 0 || e.DataDictionary[_commands.Application_mode.PathIndex + Convert.ToInt32(_commands.Application_mode.IO).ToString() + _commands.Application_mode.BitLength.ToString() + _commands.Application_mode.BitIndex.ToString()] == 1)  // If application mode is in standard mode
+            if (e.DataDictionary[_commands.Application_mode.Path] == 0 || e.DataDictionary[_commands.Application_mode.Path] == 1)  // If application mode is in standard mode
             {
-                _limitSwitch1Mode = e.DataDictionary[_commands.Limit_value_monitoring_liv11.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv11.IO).ToString() + _commands.Limit_value_monitoring_liv11.BitLength.ToString() + _commands.Limit_value_monitoring_liv11.BitIndex.ToString()];
-                _limitSwitch1Input = e.DataDictionary[_commands.Signal_source_liv12.PathIndex + Convert.ToInt32(_commands.Signal_source_liv12.IO).ToString() + _commands.Signal_source_liv12.BitLength.ToString() + _commands.Signal_source_liv12.BitIndex.ToString()];
-                _limitSwitch1ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv13.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv13.IO).ToString() + _commands.Switch_on_level_liv13.BitLength.ToString() + _commands.Switch_on_level_liv13.BitIndex.ToString()];
-                _limitSwitch1HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv14.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv14.IO).ToString() + _commands.Switch_off_level_liv14.BitLength.ToString() + _commands.Switch_off_level_liv14.BitIndex.ToString()];
+                _limitSwitch1Input = e.DataDictionary[_commands.LimitValue1Mode.Path];
+                _limitSwitch1Mode = e.DataDictionary[_commands.LimitValue1Input.Path];
+                _limitSwitch1ActivationLevelLowerBandLimit = e.DataDictionary[_commands.LimitValue1ActivationLevelLowerBandLimit.Path];
+                _limitSwitch1HysteresisBandHeight = e.DataDictionary[_commands.LimitValue1HysteresisBandHeight.Path];
 
-                _limitSwitch2Mode = e.DataDictionary[_commands.Limit_value_monitoring_liv21.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv21.IO).ToString() + _commands.Limit_value_monitoring_liv21.BitLength.ToString() + _commands.Limit_value_monitoring_liv21.BitIndex.ToString()];
-                _limitSwitch2Source = e.DataDictionary[_commands.Signal_source_liv22.PathIndex + Convert.ToInt32(_commands.Signal_source_liv22.IO).ToString() + _commands.Signal_source_liv22.BitLength.ToString() + _commands.Signal_source_liv22.BitIndex.ToString()];
-
-                /*
-                _limitSwitch2ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv23.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv23.IO).ToString() + _commands.Switch_on_level_liv23.BitLength.ToString() + _commands.Switch_on_level_liv23.BitIndex.ToString()];
-                _limitSwitch2HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv24.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv24.IO).ToString() + _commands.Switch_off_level_liv24.BitLength.ToString() + _commands.Switch_off_level_liv24.BitIndex.ToString()];
-
-                _limitSwitch3Mode = e.DataDictionary[_commands.Limit_value_monitoring_liv31.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv31.IO).ToString() + _commands.Limit_value_monitoring_liv31.BitLength.ToString() + _commands.Limit_value_monitoring_liv31.BitIndex.ToString()];
-                _limitSwitch3Source = e.DataDictionary[_commands.Signal_source_liv32.PathIndex + Convert.ToInt32(_commands.Signal_source_liv32.IO).ToString() + _commands.Signal_source_liv32.BitLength.ToString() + _commands.Signal_source_liv32.BitIndex.ToString()];
-                _limitSwitch3ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv33.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv33.IO).ToString() + _commands.Switch_on_level_liv33.BitLength.ToString() + _commands.Switch_on_level_liv33.BitIndex.ToString()];
-                _limitSwitch3HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv34.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv34.IO).ToString() + _commands.Switch_off_level_liv34.BitLength.ToString() + _commands.Switch_off_level_liv34.BitIndex.ToString()];
-
-                _limitSwitch4Mode = e.DataDictionary[_commands.Limit_value_monitoring_liv41.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv41.IO).ToString() + _commands.Limit_value_monitoring_liv41.BitLength.ToString() + _commands.Limit_value_monitoring_liv41.BitIndex.ToString()];
-                _limitSwitch4Source = e.DataDictionary[_commands.Signal_source_liv42.PathIndex + Convert.ToInt32(_commands.Signal_source_liv42.IO).ToString() + _commands.Signal_source_liv42.BitLength.ToString() + _commands.Signal_source_liv42.BitIndex.ToString()];
-                _limitSwitch4ActivationLevelLowerBandLimit = e.DataDictionary[_commands.Switch_on_level_liv43.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv43.IO).ToString() + _commands.Switch_on_level_liv43.BitLength.ToString() + _commands.Switch_on_level_liv43.BitIndex.ToString()];
-                _limitSwitch4HysteresisBandHeight = e.DataDictionary[_commands.Switch_off_level_liv44.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv44.IO).ToString() + _commands.Switch_off_level_liv44.BitLength.ToString() + _commands.Switch_off_level_liv44.BitIndex.ToString()];
-                */
+                _limitSwitch2Mode = e.DataDictionary[_commands.LimitValue2Source.Path];
+                _limitSwitch2Source = e.DataDictionary[_commands.LimitValue2Mode.Path];
+                _limitSwitch2ActivationLevelLowerBandLimit = e.DataDictionary[_commands.LimitValue2ActivationLevelLowerBandLimit.Path];
+                _limitSwitch2HysteresisBandHeight = e.DataDictionary[_commands.LimitValue2HysteresisBandHeight.Path];
+                
+                _limitSwitch3Mode = e.DataDictionary[_commands.LimitValue3Source.Path];
+                _limitSwitch3Source = e.DataDictionary[_commands.LimitValue3Mode.Path];
+                _limitSwitch3ActivationLevelLowerBandLimit = e.DataDictionary[_commands.LimitValue3ActivationLevelLowerBandLimit.Path];
+                _limitSwitch3HysteresisBandHeight = e.DataDictionary[_commands.LimitValue3HysteresisBandHeight.Path];
+                
+                _limitSwitch4Mode = e.DataDictionary[_commands.LimitValue3Source.Path];
+                _limitSwitch4Source = e.DataDictionary[_commands.LimitValue3Mode.Path];
+                _limitSwitch4ActivationLevelLowerBandLimit = e.DataDictionary[_commands.LimitValue3ActivationLevelLowerBandLimit.Path];
+                _limitSwitch4HysteresisBandHeight = e.DataDictionary[_commands.LimitValue3HysteresisBandHeight.Path];
             }
         }
         #endregion
@@ -226,7 +215,7 @@ namespace HBM.Weighing.API.Data
             get { return _input1; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_1.PathIndex, value);
+                _connection.Write(_commands.Status_digital_input_1.Register, value);
                 _input1 = value;
             }
         }
@@ -235,7 +224,7 @@ namespace HBM.Weighing.API.Data
             get { return _input2; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_2.PathIndex, value);
+                _connection.Write(_commands.Status_digital_input_2.Register, value);
                 _input2 = value;
             }
         }
@@ -244,7 +233,7 @@ namespace HBM.Weighing.API.Data
             get { return _input3; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_3.PathIndex, value);
+                _connection.Write(_commands.Status_digital_input_3.Register, value);
                 _input3 = value;
             }
         }
@@ -253,7 +242,7 @@ namespace HBM.Weighing.API.Data
             get { return _input4; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_4.PathIndex, value);
+                _connection.Write(_commands.Status_digital_input_4.Register, value);
                 _input4 = value;
             }
         }
@@ -262,7 +251,7 @@ namespace HBM.Weighing.API.Data
             get { return _output1; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_1.PathIndex, value);
+                _connection.Write(_commands.Status_digital_output_1.Register, value);
                 _output1 = value;
             }
         }
@@ -271,7 +260,7 @@ namespace HBM.Weighing.API.Data
             get { return _output2; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_2.PathIndex, value);
+                _connection.Write(_commands.Status_digital_output_2.Register, value);
                 _output2 = value;
             }
         }
@@ -280,7 +269,7 @@ namespace HBM.Weighing.API.Data
             get { return _output3; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_3.PathIndex, value);
+                _connection.Write(_commands.Status_digital_output_3.Register, value);
                 _output3 = value;
             }
         }
@@ -289,7 +278,7 @@ namespace HBM.Weighing.API.Data
             get { return _output4; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_4.PathIndex, value);
+                _connection.Write(_commands.Status_digital_output_4.Register, value);
                 _output4 = value;
             }
         }
@@ -333,11 +322,6 @@ namespace HBM.Weighing.API.Data
         {
             get { return _weightMemoryNet; }
         }
-        public int WeightStorage
-        {
-            get { return _weight_storage; }
-            set { this._weight_storage = value; }
-        }
         #endregion
 
         #region Get-/Set-properties for standard mode 
@@ -347,7 +331,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1Input; }
             set
             {
-                _connection.Write(_commands.Tare_value.PathIndex, value);
+                _connection.Write(_commands.Tare_value.Register, value);
                 _limitSwitch1Input = value;
             }
         }
@@ -356,7 +340,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1Mode; }
             set
             {
-                _connection.Write(_commands.Signal_source_liv12.PathIndex, value);
+                _connection.Write(_commands.LimitValue1Input.Register, value);
                 _limitSwitch1Mode = value;
             }
         }
@@ -365,7 +349,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.Write(_commands.Limit_value_monitoring_liv11.PathIndex, value);
+                _connection.Write(_commands.LimitValue1Mode.Register, value);
                 _limitSwitch1ActivationLevelLowerBandLimit = value;
             }
         }
@@ -374,7 +358,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.Signal_source_liv12.PathIndex, value);
+                _connection.Write(_commands.LimitValue1HysteresisBandHeight.Register, value);
                 _limitSwitch1HysteresisBandHeight = value;
             }
         }
@@ -383,7 +367,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1ActivationLevelLowerBandLimit; }
             set
             {
-                this._connection.WriteArray(_commands.Switch_on_level_liv13.PathIndex, value);
+                this._connection.WriteArray(_commands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch1ActivationLevelLowerBandLimit = value;
             }
         }
@@ -392,16 +376,17 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1HysteresisBandHeight; }
             set
             {
-                _connection.WriteArray(_commands.Switch_off_level_liv14.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue1HysteresisBandHeight.Register, value);
                 _limitSwitch1HysteresisBandHeight = value;
             }
         }
+
         public int LimitSwitch2Source // Type : unsigned integer 8 Bit
         {
             get { return _limitSwitch2Source; }
             set
             {
-                _connection.Write(_commands.Signal_source_liv22.PathIndex, value);
+                _connection.Write(_commands.LimitValue2Source.Register, value);
                 _limitSwitch2Source = value;
             }
         }
@@ -410,7 +395,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2Mode; }
             set
             {
-                _connection.Write(_commands.Limit_value_monitoring_liv21.PathIndex, value);
+                _connection.Write(_commands.LimitValue2Mode.Register, value);
                 _limitSwitch2Mode = value;
             }
         }
@@ -419,7 +404,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.Write(_commands.Switch_on_level_liv23.PathIndex, value);
+                _connection.Write(_commands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch2ActivationLevelLowerBandLimit = value;
             }
         }
@@ -428,7 +413,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.Switch_off_level_liv24.PathIndex, value);
+                _connection.Write(_commands.LimitValue2HysteresisBandHeight.Register, value);
                 _limitSwitch2HysteresisBandHeight = value;
             }
         }
@@ -437,7 +422,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2ActivationLevelLowerBandLimit; }
             set
             {
-                this._connection.Write(_commands.Switch_off_level_liv34.PathIndex, value);
+                this._connection.Write(_commands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch2ActivationLevelLowerBandLimit = value;
             }
         }
@@ -446,7 +431,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.Switch_off_level_liv24.PathIndex, value);
+                _connection.Write(_commands.LimitValue2HysteresisBandHeight.Register, value);
                 _limitSwitch2HysteresisBandHeight = value;
             }
         }
@@ -455,7 +440,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3Source; }
             set
             {
-                _connection.Write(_commands.Signal_source_liv32.PathIndex, value);
+                _connection.Write(_commands.LimitValue3Source.Register, value);
                 _limitSwitch3Source = value;
             }
         }
@@ -464,7 +449,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3Mode; }
             set
             {
-                _connection.Write(_commands.Limit_value_monitoring_liv31.PathIndex, value);
+                _connection.Write(_commands.LimitValue3Mode.Register, value);
                 _limitSwitch3Mode = value;
             }
         }
@@ -473,7 +458,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.WriteArray(_commands.Switch_on_level_liv33.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch3ActivationLevelLowerBandLimit = value;
             }
         }
@@ -482,7 +467,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3HysteresisBandHeight; }
             set
             {
-                _connection.WriteArray(_commands.Switch_off_level_liv34.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue3HysteresisBandHeight.Register, value);
                 _limitSwitch3HysteresisBandHeight = value;
             }
         }
@@ -491,7 +476,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.Write(_commands.Signal_source_liv42.PathIndex, value);
+                _connection.Write(_commands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch3ActivationLevelLowerBandLimit = value;
             }
         }
@@ -500,7 +485,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.Limit_value_monitoring_liv41.PathIndex, value);
+                _connection.Write(_commands.LimitValue3HysteresisBandHeight.Register, value);
                 _limitSwitch3HysteresisBandHeight = value;
             }
         }
@@ -509,7 +494,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4Source; }
             set
             {
-                _connection.WriteArray(_commands.Switch_on_level_liv43.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue4Source.Register, value);
                 _limitSwitch4Source = value;
             }
         }
@@ -518,7 +503,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4Mode; }
             set
             {
-                _connection.WriteArray(_commands.Switch_off_level_liv44.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue4Mode.Register, value);
                 _limitSwitch4Mode = value;
             }
         }
@@ -527,7 +512,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.WriteArray(_commands.Switch_on_level_liv43.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue4ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch4ActivationLevelLowerBandLimit = value;
             }
         }
@@ -536,7 +521,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4HysteresisBandHeight; }
             set
             {
-                _connection.WriteArray(_commands.Switch_off_level_liv44.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue4HysteresisBandHeight.Register, value);
                 _limitSwitch4HysteresisBandHeight = value;
             }
         }
@@ -545,7 +530,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.WriteArray(_commands.Switch_on_level_liv43.PathIndex, value);
+                _connection.WriteArray(_commands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch4ActivationLevelLowerBandLimit = value;
             }
         }
@@ -554,10 +539,11 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.Switch_off_level_liv44.PathIndex, value);
+                _connection.Write(_commands.LimitValue4HysteresisBandHeight.Register, value);
                 _limitSwitch4HysteresisBandHeight = value;
             }
         }
+        public int WeightStorage { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         #endregion
     }
 }

--- a/HBM.Weighing.API/Data/ProcessDataModbus.cs
+++ b/HBM.Weighing.API/Data/ProcessDataModbus.cs
@@ -78,35 +78,29 @@ namespace HBM.Weighing.API.Data
         #region Update method
         public void UpdateProcessData(object sender, DataEventArgs e)
         {            
-            string DictionaryIndexNetValue = _commands.Net_value.PathIndex + Convert.ToInt32(_commands.Net_value.IO).ToString() + _commands.Net_value.BitLength.ToString() + _commands.Net_value.BitIndex.ToString();
-
-            NetValue = e.DataDictionary[_commands.Net_value.PathIndex + Convert.ToInt32(_commands.Net_value.IO).ToString() + _commands.Net_value.BitLength.ToString() + _commands.Net_value.BitIndex.ToString()];
-            GrossValue = e.DataDictionary[_commands.Gross_value.PathIndex + Convert.ToInt32(_commands.Gross_value.IO).ToString() + _commands.Gross_value.BitLength.ToString() + _commands.Gross_value.BitIndex.ToString()];
-
+            NetValue = e.DataDictionary[_commands.Net_value.Path];
+            GrossValue = e.DataDictionary[_commands.Gross_value.Path];
             TareValue = NetValue - GrossValue;
-            GeneralWeightError = Convert.ToBoolean(e.DataDictionary[_commands.Weighing_device_1_weight_status.PathIndex + Convert.ToInt32(_commands.Weighing_device_1_weight_status.IO).ToString() + _commands.Weighing_device_1_weight_status.BitLength.ToString() + _commands.Weighing_device_1_weight_status.BitIndex.ToString()] & 0x1);
+            GeneralWeightError = Convert.ToBoolean(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path] & 0x1);
+            ApplicationMode = (ApplicationMode)e.DataDictionary[_commands.Application_mode.Path];
 
-            ApplicationMode = (ApplicationMode)e.DataDictionary[_commands.Application_mode.PathIndex + Convert.ToInt32(_commands.Application_mode.IO).ToString() + _commands.Application_mode.BitLength.ToString() + _commands.Application_mode.BitIndex.ToString()];
-
-            /*
-            ScaleAlarm = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x2) >> 1);
-            LimitStatus = (Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0xC) >> 2;
+            ScaleAlarm = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x2) >> 1);
+            LimitStatus = (Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0xC) >> 2;
             WeightWithinLimits = (LimitStatus == 0);
             Underload = (LimitStatus == 1);
             Overload = (LimitStatus == 2);
             HigherSafeLoadLimit = (LimitStatus == 3);
-            WeightMoving = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x10) >> 4);
-            ScaleSealIsOpen = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x20) >> 5);
-            ManualTare = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x40) >> 6);
-            TareMode = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x80) >> 7);
-            ScaleRange = (Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x300) >> 8;
-            ZeroRequired = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x400) >> 10);
-            CenterOfZero = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x800) >> 11);
-            InsideZero = Convert.ToBoolean((Convert.ToInt32(e.DataDictionaryModbus[_commands.Weighing_device_1_weight_status]) & 0x1000) >> 12);
-            */
+            WeightMoving = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x10) >> 4);
+            ScaleSealIsOpen = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x20) >> 5);
+            ManualTare = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x40) >> 6);
+            TareMode = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x80) >> 7);
+            ScaleRange = (Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x300) >> 8;
+            ZeroRequired = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x400) >> 10);
+            CenterOfZero = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x800) >> 11);
+            InsideZero = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[_commands.Weighing_device_1_weight_status.Path]) & 0x1000) >> 12);
 
-            Decimals = e.DataDictionary[_commands.Decimals.PathIndex + Convert.ToInt32(_commands.Decimals.IO).ToString() + _commands.Decimals.BitLength.ToString() + _commands.Decimals.BitIndex.ToString()];
-            Unit = e.DataDictionary[_commands.Unit_prefix_fixed_parameter.PathIndex + Convert.ToInt32(_commands.Unit_prefix_fixed_parameter.IO).ToString() + _commands.Unit_prefix_fixed_parameter.BitLength.ToString() + _commands.Unit_prefix_fixed_parameter.BitIndex.ToString()];        
+            Decimals = e.DataDictionary[_commands.Decimals.Path];
+            Unit = e.DataDictionary[_commands.Unit_prefix_fixed_parameter.Path];        
         }
         #endregion
 

--- a/HBM.Weighing.API/WTX/Modbus/ModbusCommand.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusCommand.cs
@@ -36,23 +36,32 @@ namespace HBM.Weighing.API.WTX.Modbus
 {
     public class ModbusCommand
     {
-        public ModbusCommand(DataType DataTypeParam, string PathIndexParam, IOType IOParam , int BitIndexParam, int BitLengthParam)
+        private string path;
+
+        public ModbusCommand(DataType dataType, string register, IOType io , ApplicationMode app, int bitIndex, int bitLength)
         {
-            this.DataType  = DataTypeParam;
-            this.PathIndex = PathIndexParam;
-            this.IO = IOParam;
-            this.BitIndex  = BitIndexParam;
-            this.BitLength = BitLengthParam;
+            this.DataType  = dataType;
+            this.Register  = register;
+            this.IO  = io;
+            this.App = app;
+            this.BitIndex  = bitIndex;
+            this.BitLength = bitLength;
+
+            this.Path = register + dataType + app + io + bitIndex + bitLength;
         }
 
         public DataType DataType { get; private set; }
 
-        public string PathIndex { get; private set; }
+        public string Register { get; private set; }
 
         public IOType IO { get; private set; }
+
+        public ApplicationMode App { get; private set; } 
 
         public int BitIndex { get; private set; }
 
         public int BitLength { get; private set; }
+
+        public string Path { get; private set; }
     }
 }

--- a/HBM.Weighing.API/WTX/Modbus/ModbusCommands.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusCommands.cs
@@ -45,140 +45,284 @@ namespace HBM.Weighing.API.WTX.Modbus
     /// </summary>
     public class ModbusCommands
     {
+        public List<ModbusCommand> items;
+
         public ModbusCommands()
         {
-            // region : ID Commands : Memory - day, month, year, seqNumber, gross, net
+            items = new List<ModbusCommand>();
 
+            this.CreateList();
+
+            // region : ID Commands : Memory - day, month, year, seqNumber, gross, net
+            //Limit_value_monitoring_liv31 Minimum_fine_flow
             // For standard mode: 
-            ReadWeightMemDay_ID   = new ModbusCommand(DataType.Int16, "9", IOType.Input, 0, 0);
-            ReadWeightMemMonth_ID = new ModbusCommand(DataType.Int16, "10", IOType.Input, 0, 0);
-            ReadWeightMemYear_ID  = new ModbusCommand(DataType.Int16, "11", IOType.Input, 0, 0);
-            ReadWeightMemSeqNumber_ID = new ModbusCommand(DataType.Int16, "12", IOType.Input, 0, 0);
-            ReadWeightMemGross_ID = new ModbusCommand(DataType.Int16, "13", IOType.Input, 0, 0);
-            ReadWeightMemNet_ID   = new ModbusCommand(DataType.Int16, "14", IOType.Input, 0, 0);
+            ReadWeightMemDay_ID   = new ModbusCommand(DataType.Int16, "9",  IOType.Input, ApplicationMode.Standard, 0, 0);
+            ReadWeightMemMonth_ID = new ModbusCommand(DataType.Int16, "10", IOType.Input, ApplicationMode.Standard, 0, 0);
+            ReadWeightMemYear_ID  = new ModbusCommand(DataType.Int16, "11", IOType.Input, ApplicationMode.Standard, 0, 0);
+            ReadWeightMemSeqNumber_ID = new ModbusCommand(DataType.Int16, "12", IOType.Input, ApplicationMode.Standard, 0, 0);
+            ReadWeightMemGross_ID = new ModbusCommand(DataType.Int16, "13", IOType.Input, ApplicationMode.Standard, 0, 0);
+            ReadWeightMemNet_ID   = new ModbusCommand(DataType.Int16, "14", IOType.Input, ApplicationMode.Standard, 0, 0);
 
             // For filler mode: 
-            WriteWeightMemDay_ID   = new ModbusCommand(DataType.Int16, "32", IOType.Output, 0, 0);
-            WriteWeightMemMonth_ID = new ModbusCommand(DataType.Int16, "33", IOType.Output, 0, 0);
-            WriteWeightMemYear_ID  = new ModbusCommand(DataType.Int16, "34", IOType.Output, 0, 0);
-            WriteWeightMemSeqNumber_ID = new ModbusCommand(DataType.Int16, "35", IOType.Output, 0, 0);
-            WriteWeightMemGross_ID = new ModbusCommand(DataType.Int16, "36", IOType.Output, 0, 0);
-            WriteWeightMemNet_ID   = new ModbusCommand(DataType.Int16, "37", IOType.Output, 0, 0);
+            WriteWeightMemDay_ID   = new ModbusCommand(DataType.Int16, "32", IOType.Output, ApplicationMode.Filler, 0, 0);
+            WriteWeightMemMonth_ID = new ModbusCommand(DataType.Int16, "33", IOType.Output, ApplicationMode.Filler, 0, 0);
+            WriteWeightMemYear_ID  = new ModbusCommand(DataType.Int16, "34", IOType.Output, ApplicationMode.Filler, 0, 0);
+            WriteWeightMemSeqNumber_ID = new ModbusCommand(DataType.Int16, "35", IOType.Output, ApplicationMode.Filler, 0, 0);
+            WriteWeightMemGross_ID = new ModbusCommand(DataType.Int16, "36", IOType.Output, ApplicationMode.Filler, 0, 0);
+            WriteWeightMemNet_ID   = new ModbusCommand(DataType.Int16, "37", IOType.Output, ApplicationMode.Filler, 0, 0);
 
             // region ID Commands : Maintenance - Calibration
 
-            Ldw_dead_weight   = new ModbusCommand(DataType.S32, "48", IOType.Output, 0, 0);              // LDW = Nullpunkt
-            Lwt_nominal_value = new ModbusCommand(DataType.S32, "50", IOType.Output, 0, 0);              // LWT = Nennwert
-            Lft_scale_calibration_weight = new ModbusCommand(DataType.S32, "46", IOType.Output, 0, 0);   // LFT = LFT scale calibration weight
+            Lft_scale_calibration_weight = new ModbusCommand(DataType.S32, "46", IOType.Output, ApplicationMode.Standard, 0, 0);   // LFT = LFT scale calibration weight
+            Ldw_dead_weight   = new ModbusCommand(DataType.S32, "48", IOType.Output, ApplicationMode.Standard, 0, 0);              // LDW = Nullpunkt
+            Lwt_nominal_value = new ModbusCommand(DataType.S32, "50", IOType.Output, ApplicationMode.Standard, 0, 0);              // LWT = Nennwert
 
             // region ID commands for process data
-            Net_value   = new ModbusCommand(DataType.U08, "0", IOType.Input, 0, 0);
-            Gross_value = new ModbusCommand(DataType.U08, "2", IOType.Input, 0, 0);
-            Zero_value  = new ModbusCommand(DataType.U08, "", IOType.Input, 0, 0);
+            Net_value   = new ModbusCommand(DataType.Int32, "0", IOType.Input, ApplicationMode.Standard, 32, 0);
+            Gross_value = new ModbusCommand(DataType.Int32, "2", IOType.Input, ApplicationMode.Standard, 32, 0);
+            Zero_value  = new ModbusCommand(DataType.Int32, "",  IOType.Input, ApplicationMode.Standard, 32, 0);
 
-            Weighing_device_1_weight_status = new ModbusCommand(DataType.U08, "4", IOType.Input, 0, 0);
+            Weighing_device_1_weight_status = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 0, 0);
 
-            Limit_status = new ModbusCommand(DataType.U08, "4", IOType.Input, 2, 2);                   // data word = 4 ; length = 2 ; offset = 2;
-            Unit_prefix_fixed_parameter = new ModbusCommand(DataType.U08, "5", IOType.Input, 2, 7);    // data word = 5 ; length = 2 ; offset = 7;
+            GeneralWeightError = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 0);
+            ScaleAlarmTriggered = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 1);
+            Limit_status = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 2, 2);                   // data word = 4 ; length = 2 ; offset = 2;
+            WeightMoving = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 4);
+            ScaleSealIsOpen = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 5);
+            ManualTare = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 6);
+            WeightType = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 7);
+            ScaleRange = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 2, 8);
+            ZeroRequired = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 10);
+            WeightinCenterOfZero = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 11);
+            WeightinZeroRange = new ModbusCommand(DataType.U08, "4", IOType.Input, ApplicationMode.Standard, 1, 12);
 
-            Application_mode = new ModbusCommand(DataType.U08, "5", IOType.Input, 2, 0);               // data word = 5 ; length = 2 ; offset = 0;
-            Decimals = new ModbusCommand(DataType.U08, "5", IOType.Input, 3, 4);                       // data word = 5 ; length = 3 ; offset = 4;
-            Scale_command_status = new ModbusCommand(DataType.U08, "5", IOType.Input, 1, 15);          // data word = 5 ; length = 1 ; offset = 15;
-
-            Scale_command = new ModbusCommand(DataType.U08, "", IOType.Input, 0, 0);
+            Application_mode = new ModbusCommand(DataType.U08, "5", IOType.Input, ApplicationMode.Standard, 2, 0);               // data word = 5 ; length = 2 ; offset = 0;
+            Decimals = new ModbusCommand(DataType.U08, "5", IOType.Input, ApplicationMode.Standard, 3, 4);                       // data word = 5 ; length = 3 ; offset = 4;
+            Unit_prefix_fixed_parameter = new ModbusCommand(DataType.U08, "5", IOType.Input, ApplicationMode.Standard, 2, 7);    // data word = 5 ; length = 2 ; offset = 7;
+            Handshake = new ModbusCommand(DataType.U08, "5", IOType.Input, ApplicationMode.Standard, 1, 14);
+            Status = new ModbusCommand(DataType.U08, "5", IOType.Input, ApplicationMode.Standard, 1, 15);          // data word = 5 ; length = 1 ; offset = 15;
 
             // region ID commands for standard mode
-            Status_digital_input_1 = new ModbusCommand(DataType.U08, "6", IOType.Input, 1, 1);    // IS1
-            Status_digital_input_2 = new ModbusCommand(DataType.U08, "6", IOType.Input, 2, 1);    // IS2
-            Status_digital_input_3 = new ModbusCommand(DataType.U08, "6", IOType.Input, 3, 1);    // IS3
-            Status_digital_input_4 = new ModbusCommand(DataType.U08, "6", IOType.Input, 4, 1);    // IS4
+            Status_digital_input_1 = new ModbusCommand(DataType.U08, "6", IOType.Input, ApplicationMode.Standard, 1, 1);    // IS1
+            Status_digital_input_2 = new ModbusCommand(DataType.U08, "6", IOType.Input, ApplicationMode.Standard, 2, 1);    // IS2
+            Status_digital_input_3 = new ModbusCommand(DataType.U08, "6", IOType.Input, ApplicationMode.Standard, 3, 1);    // IS3
+            Status_digital_input_4 = new ModbusCommand(DataType.U08, "6", IOType.Input, ApplicationMode.Standard, 4, 1);    // IS4
 
-            Status_digital_output_1 = new ModbusCommand(DataType.U08, "7", IOType.Input, 1, 1);   // OS1
-            Status_digital_output_2 = new ModbusCommand(DataType.U08, "7", IOType.Input, 2, 1);   // OS2
-            Status_digital_output_3 = new ModbusCommand(DataType.U08, "7", IOType.Input, 3, 1);   // OS3
-            Status_digital_output_4 = new ModbusCommand(DataType.U08, "7", IOType.Input, 4, 1);   // OS4
+            Status_digital_output_1 = new ModbusCommand(DataType.U08, "7", IOType.Input, ApplicationMode.Standard, 1, 1);   // OS1
+            Status_digital_output_2 = new ModbusCommand(DataType.U08, "7", IOType.Input, ApplicationMode.Standard, 2, 1);   // OS2
+            Status_digital_output_3 = new ModbusCommand(DataType.U08, "7", IOType.Input, ApplicationMode.Standard, 3, 1);   // OS3
+            Status_digital_output_4 = new ModbusCommand(DataType.U08, "7", IOType.Input, ApplicationMode.Standard, 4, 1);   // OS4
 
-            Limit_value = new ModbusCommand(DataType.U08, "8", IOType.Input, 0, 0);   // LVS , standard
+            Limit_value = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Standard, 0, 0);   // LVS , standard
+            Tare_value = new ModbusCommand(DataType.U08, "2", IOType.Input, ApplicationMode.Standard, 0, 0);  // manual tare value
 
-            Tare_value = new ModbusCommand(DataType.U08, "2", IOType.Input, 0, 0);  // manual tare value
+            LimitValue1Input = new ModbusCommand(DataType.U08, "4", IOType.Output, ApplicationMode.Standard, 0, 0); 
+            LimitValue1Mode = new ModbusCommand(DataType.U08, "5", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue1ActivationLevelLowerBandLimit = new ModbusCommand(DataType.S32, "6", IOType.Output, ApplicationMode.Standard, 0, 0);       
+            LimitValue1HysteresisBandHeight = new ModbusCommand(DataType.S32, "8", IOType.Output, ApplicationMode.Standard, 0, 0);       
 
-            Limit_value_monitoring_liv11 = new ModbusCommand(DataType.U08, "4", IOType.Output, 0, 0); // = Grenzwertüberwachung 
-            Signal_source_liv12 = new ModbusCommand(DataType.U08, "5", IOType.Output, 0, 0);
-            Switch_on_level_liv13 = new ModbusCommand(DataType.S32, "6", IOType.Output, 0, 0);        // = Einschaltpegel
-            Switch_off_level_liv14 = new ModbusCommand(DataType.S32, "8", IOType.Output, 0, 0);       // = Ausschaltpegel
+            LimitValue2Source = new ModbusCommand(DataType.U08, "10", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue2Mode = new ModbusCommand(DataType.U08, "11", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue2ActivationLevelLowerBandLimit = new ModbusCommand(DataType.S32, "12", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue2HysteresisBandHeight = new ModbusCommand(DataType.S32, "14", IOType.Output, ApplicationMode.Standard, 0, 0);
 
-            Limit_value_monitoring_liv21 = new ModbusCommand(DataType.U08, "10", IOType.Output, 0, 0);
-            Signal_source_liv22 = new ModbusCommand(DataType.U08, "11", IOType.Output, 0, 0);
-            Switch_on_level_liv23 = new ModbusCommand(DataType.S32, "12", IOType.Output, 0, 0);
-            Switch_off_level_liv24 = new ModbusCommand(DataType.S32, "14", IOType.Output, 0, 0);
+            LimitValue3Source = new ModbusCommand(DataType.U08, "16", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue3Mode = new ModbusCommand(DataType.U08, "17", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue3ActivationLevelLowerBandLimit = new ModbusCommand(DataType.S32, "18", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue3HysteresisBandHeight = new ModbusCommand(DataType.S32, "20", IOType.Output, ApplicationMode.Standard, 0, 0);
 
-            Limit_value_monitoring_liv31 = new ModbusCommand(DataType.U08, "16", IOType.Output, 0, 0);
-            Signal_source_liv32 = new ModbusCommand(DataType.U08, "17", IOType.Output, 0, 0);
-            Switch_on_level_liv33 = new ModbusCommand(DataType.S32, "18", IOType.Output, 0, 0);
-            Switch_off_level_liv34 = new ModbusCommand(DataType.S32, "20", IOType.Output, 0, 0);
-
-            Limit_value_monitoring_liv41 = new ModbusCommand(DataType.U08, "22", IOType.Output, 0, 0);
-            Signal_source_liv42 = new ModbusCommand(DataType.U08, "23", IOType.Output, 0, 0);
-            Switch_on_level_liv43 = new ModbusCommand(DataType.S32, "24", IOType.Output, 0, 0);
-            Switch_off_level_liv44 = new ModbusCommand(DataType.S32, "26", IOType.Output, 0, 0);
+            LimitValue4Source = new ModbusCommand(DataType.U08, "22", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue4Mode = new ModbusCommand(DataType.U08, "23", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue4ActivationLevelLowerBandLimit = new ModbusCommand(DataType.S32, "24", IOType.Output, ApplicationMode.Standard, 0, 0);
+            LimitValue4HysteresisBandHeight = new ModbusCommand(DataType.S32, "26", IOType.Output, ApplicationMode.Standard, 0, 0);
 
             // region ID commands for filler data
 
-            CoarseFlow = new ModbusCommand(DataType.U08, "8", IOType.Input, 0, 1);               // data input word 8, bit .0, application mode=filler
-            FineFlow = new ModbusCommand(DataType.U08, "8", IOType.Input, 1, 1);                 // data input word 8, bit .1, application mode=filler
-            Ready = new ModbusCommand(DataType.U08, "8", IOType.Input, 2, 1);                    // data input word 8, bit .2, application mode=filler
-            ReDosing = new ModbusCommand(DataType.U08, "8",  IOType.Input, 3, 1);                // data input word 8, bit .3, application mode=filler; RDS = Nachdosieren
-            Emptying = new ModbusCommand(DataType.U08, "8",  IOType.Input, 4, 1);                // data input word 8, bit .4, application mode=filler
-            FlowError = new ModbusCommand(DataType.U08, "8", IOType.Input, 5, 1);                // data input word 8, bit .5, application mode=filler
-            Alarm = new ModbusCommand(DataType.U08, "8", IOType.Input, 6, 1);                    // data input word 8, bit .6, application mode=filler
-            AdcOverUnderload = new ModbusCommand(DataType.U08, "8", IOType.Input, 7, 1);         // data input word 8, bit .7, application mode=filler
-            MaximalDosingTimeInput = new ModbusCommand(DataType.U08, "8", IOType.Input, 8, 1);   // data input word 8, bit .8, application mode=filler
-            LegalForTradeOperation = new ModbusCommand(DataType.U08, "8", IOType.Input, 9, 1);   // data input word 8, bit .9, application mode=filler
-            ToleranceErrorPlus = new ModbusCommand(DataType.U08, "8", IOType.Input, 10, 1);      // data input word 8, bit .10, application mode=filler
-            ToleranceErrorMinus = new ModbusCommand(DataType.U08, "8", IOType.Input, 11, 1);     // data input word 8, bit .11, application mode=filler
-            StatusInput1 = new ModbusCommand(DataType.U08, "8", IOType.Input, 14, 1);            // data input word 8, bit .14, application mode=filler
-            GeneralScaleError = new ModbusCommand(DataType.U08, "8", IOType.Input, 15, 1);       // data input word 8, bit .15, application mode=filler
+            CoarseFlow = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 0, 1);               // data input word 8, bit .0, application mode=filler
+            FineFlow = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 1, 1);                 // data input word 8, bit .1, application mode=filler
+            Ready = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 2, 1);                    // data input word 8, bit .2, application mode=filler
+            ReDosing = new ModbusCommand(DataType.U08, "8",  IOType.Input, ApplicationMode.Filler, 3, 1);                // data input word 8, bit .3, application mode=filler; RDS = Nachdosieren
+            Emptying = new ModbusCommand(DataType.U08, "8",  IOType.Input, ApplicationMode.Filler, 4, 1);                // data input word 8, bit .4, application mode=filler
+            FlowError = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 5, 1);                // data input word 8, bit .5, application mode=filler
+            Alarm = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 6, 1);                    // data input word 8, bit .6, application mode=filler
+            AdcOverUnderload = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 7, 1);         // data input word 8, bit .7, application mode=filler
+            MaximalDosingTimeInput = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 8, 1);   // data input word 8, bit .8, application mode=filler
+            LegalForTradeOperation = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 9, 1);   // data input word 8, bit .9, application mode=filler
+            ToleranceErrorPlus = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 10, 1);      // data input word 8, bit .10, application mode=filler
+            ToleranceErrorMinus = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 11, 1);     // data input word 8, bit .11, application mode=filler
+            StatusInput1 = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 14, 1);            // data input word 8, bit .14, application mode=filler
+            GeneralScaleError = new ModbusCommand(DataType.U08, "8", IOType.Input, ApplicationMode.Filler, 15, 1);       // data input word 8, bit .15, application mode=filler
 
-            TotalWeight = new ModbusCommand(DataType.S32, "18", IOType.Input, 0, 0);             // data input word 18, application mode=filler
-            Dosing_time = new ModbusCommand(DataType.U16, "24", IOType.Input, 0, 0);             // DST = Dosieristzeit
-            Coarse_flow_time = new ModbusCommand(DataType.U16, "25", IOType.Input, 0, 0);        // CFT = Grobstromzeit
-            CurrentFineFlowTime = new ModbusCommand(DataType.U16, "26", IOType.Input, 0, 0);     // data input word 26, application mode=filler; FFT = Feinstromzeit
-            ParameterSetProduct = new ModbusCommand(DataType.U08, "27", IOType.Input, 0, 0);     // data input word 27, application mode=filler
+            TotalWeight = new ModbusCommand(DataType.S32, "18", IOType.Input, ApplicationMode.Filler, 0, 0);             // data input word 18, application mode=filler
+            Dosing_time = new ModbusCommand(DataType.U16, "24", IOType.Input, ApplicationMode.Filler, 0, 0);             // DST = Dosieristzeit
+            Coarse_flow_time = new ModbusCommand(DataType.U16, "25", IOType.Input, ApplicationMode.Filler, 0, 0);        // CFT = Grobstromzeit
+            CurrentFineFlowTime = new ModbusCommand(DataType.U16, "26", IOType.Input, ApplicationMode.Filler, 0, 0);     // data input word 26, application mode=filler; FFT = Feinstromzeit
+            ParameterSetProduct = new ModbusCommand(DataType.U08, "27", IOType.Input, ApplicationMode.Filler, 0, 0);     // data input word 27, application mode=filler
 
-            TargetFillingWeight = new ModbusCommand(DataType.S32, "10", IOType.Output, 0, 0);        // data output word 10, application mode=filler
-            Residual_flow_time = new ModbusCommand(DataType.U16, "9", IOType.Output, 0, 0);          // RFT = Nachstromzeit
-            //Reference_value_dosing = new ModbusCommand(1, "10", IOType.Output, 0, 0);     // FWT = Sollwert dosieren = Target filling weight
-            Coarse_flow_cut_off_point = new ModbusCommand(DataType.S32, "12", IOType.Output, 0, 0);  // CFD = Grobstromabschaltpunkt
-            Fine_flow_cut_off_point = new ModbusCommand(DataType.S32, "14", IOType.Output, 0, 0);    // FFD = Feinstromabschaltpunkt
+            TargetFillingWeight = new ModbusCommand(DataType.S32, "10", IOType.Output, ApplicationMode.Filler, 0, 0);        // data output word 10, application mode=filler
+            Residual_flow_time = new ModbusCommand(DataType.U16, "9", IOType.Output, ApplicationMode.Filler, 0, 0);          // RFT = Nachstromzeit
+            //Reference_value_dosing = new ModbusCommand(1, "10", IOType.Output, ApplicationMode.Filler,0, 0);     // FWT = Sollwert dosieren = Target filling weight
+            Coarse_flow_cut_off_point = new ModbusCommand(DataType.S32, "12", IOType.Output, ApplicationMode.Filler, 0, 0);  // CFD = Grobstromabschaltpunkt
+            Fine_flow_cut_off_point = new ModbusCommand(DataType.S32, "14", IOType.Output, ApplicationMode.Filler, 0, 0);    // FFD = Feinstromabschaltpunkt
 
-            Minimum_fine_flow = new ModbusCommand(DataType.S32, "16", IOType.Output, 0, 0);          // FFM = Minimaler Feinstromanteil
-            Optimization = new ModbusCommand(DataType.U08, "18", IOType.Output, 0, 0);               // OSN = Optimierung
-            Maximal_dosing_time = new ModbusCommand(DataType.U16, "19", IOType.Output, 0, 0);        // MDT = Maximale Dosierzeit
-            Run_start_dosing = new ModbusCommand(DataType.U16, "20", IOType.Output, 0, 0);           // RUN = Start Dosieren
+            Minimum_fine_flow = new ModbusCommand(DataType.S32, "16", IOType.Output, ApplicationMode.Filler, 0, 0);          // FFM = Minimaler Feinstromanteil
+            Optimization = new ModbusCommand(DataType.U08, "18", IOType.Output, ApplicationMode.Filler, 0, 0);               // OSN = Optimierung
+            Maximal_dosing_time = new ModbusCommand(DataType.U16, "19", IOType.Output, ApplicationMode.Filler, 0, 0);        // MDT = Maximale Dosierzeit
+            Run_start_dosing = new ModbusCommand(DataType.U16, "20", IOType.Output, ApplicationMode.Filler, 0, 0);           // RUN = Start Dosieren
 
-            Lockout_time_coarse_flow = new ModbusCommand(DataType.U16, "21", IOType.Output, 0, 0);   // LTC = Sperrzeit Grobstrom
-            Lockout_time_fine_flow = new ModbusCommand(DataType.U16, "22", IOType.Output, 0, 0);     // LTF = Sperrzeit Feinstrom
-            Tare_mode = new ModbusCommand(DataType.U08, "23", IOType.Output, 0, 0);                  // TMD = Tariermodus
-            Upper_tolerance_limit = new ModbusCommand(DataType.S32, "24", IOType.Output, 0, 0);      // UTL = Obere Toleranz
+            Lockout_time_coarse_flow = new ModbusCommand(DataType.U16, "21", IOType.Output, ApplicationMode.Filler, 0, 0);   // LTC = Sperrzeit Grobstrom
+            Lockout_time_fine_flow = new ModbusCommand(DataType.U16, "22", IOType.Output, ApplicationMode.Filler, 0, 0);     // LTF = Sperrzeit Feinstrom
+            Tare_mode = new ModbusCommand(DataType.U08, "23", IOType.Output, ApplicationMode.Filler, 0, 0);                  // TMD = Tariermodus
+            Upper_tolerance_limit = new ModbusCommand(DataType.S32, "24", IOType.Output, ApplicationMode.Filler, 0, 0);      // UTL = Obere Toleranz
 
-            Lower_tolerance_limit = new ModbusCommand(DataType.S32, "26", IOType.Output, 0, 0);      // LTL = Untere Toleranz
-            Minimum_start_weight = new ModbusCommand(DataType.S32, "28", IOType.Output, 0, 0);       // MSW = Minimum Startgewicht
-            Empty_weight = new ModbusCommand(DataType.S32, "30", IOType.Output, 0, 0);
-            Tare_delay = new ModbusCommand(DataType.U16, "32", IOType.Output, 0, 0);                  // TAD = Tarierverzögerung
+            Lower_tolerance_limit = new ModbusCommand(DataType.S32, "26", IOType.Output, ApplicationMode.Filler, 0, 0);      // LTL = Untere Toleranz
+            Minimum_start_weight = new ModbusCommand(DataType.S32, "28", IOType.Output, ApplicationMode.Filler, 0, 0);       // MSW = Minimum Startgewicht
+            Empty_weight = new ModbusCommand(DataType.S32, "30", IOType.Output, ApplicationMode.Filler, 0, 0);
+            Tare_delay = new ModbusCommand(DataType.U16, "32", IOType.Output, ApplicationMode.Filler, 0, 0);                  // TAD = Tarierverzögerung
 
-            Coarse_flow_monitoring_time = new ModbusCommand(DataType.U16, "33", IOType.Output, 0, 0); // CBT = Überwachungszeit Grobstrom
-            Coarse_flow_monitoring = new ModbusCommand(DataType.U32, "34", IOType.Output, 0, 0);      // CBK = Füllstromüberwachung Grobstrom
-            Fine_flow_monitoring = new ModbusCommand(DataType.U32, "36", IOType.Output, 0, 0);        // FBK = Füllstromüberwachung Feinstrom
-            Fine_flow_monitoring_time = new ModbusCommand(DataType.U16, "38", IOType.Output, 0, 0);   // FBT = Überwachungszeit Feinstrom
+            Coarse_flow_monitoring_time = new ModbusCommand(DataType.U16, "33", IOType.Output, ApplicationMode.Filler, 0, 0); // CBT = Überwachungszeit Grobstrom
+            Coarse_flow_monitoring = new ModbusCommand(DataType.U32, "34", IOType.Output, ApplicationMode.Filler, 0, 0);      // CBK = Füllstromüberwachung Grobstrom
+            Fine_flow_monitoring = new ModbusCommand(DataType.U32, "36", IOType.Output, ApplicationMode.Filler, 0, 0);        // FBK = Füllstromüberwachung Feinstrom
+            Fine_flow_monitoring_time = new ModbusCommand(DataType.U16, "38", IOType.Output, ApplicationMode.Filler, 0, 0);   // FBT = Überwachungszeit Feinstrom
 
-            Delay_time_after_fine_flow = new ModbusCommand(DataType.U08, "39", IOType.Output, 0, 0);
-            Activation_time_after_fine_flow = new ModbusCommand(DataType.U08, "40", IOType.Output, 0, 0);
+            Delay_time_after_fine_flow = new ModbusCommand(DataType.U08, "39", IOType.Output, ApplicationMode.Filler, 0, 0);
+            Activation_time_after_fine_flow = new ModbusCommand(DataType.U08, "40", IOType.Output, ApplicationMode.Filler, 0, 0);
 
-            Systematic_difference = new ModbusCommand(DataType.U32, "41", IOType.Output, 0, 0);       // SYD = Systematische Differenz
-            DownwardsDosing = new ModbusCommand(DataType.U08, "42", IOType.Output, 0, 0);             // data output word 42, application mode=filler
-            Valve_control = new ModbusCommand(DataType.U08, "43", IOType.Output, 0, 0);               // VCT = Ventilsteuerung
-            Emptying_mode = new ModbusCommand(DataType.U08, "44", IOType.Output, 0, 0);               // EMD = Entleermodus
+            Systematic_difference = new ModbusCommand(DataType.U32, "41", IOType.Output, ApplicationMode.Filler, 0, 0);       // SYD = Systematische Differenz
+            DownwardsDosing = new ModbusCommand(DataType.U08, "42", IOType.Output, ApplicationMode.Filler, 0, 0);             // data output word 42, application mode=filler
+            Valve_control = new ModbusCommand(DataType.U08, "43", IOType.Output, ApplicationMode.Filler, 0, 0);               // VCT = Ventilsteuerung
+            Emptying_mode = new ModbusCommand(DataType.U08, "44", IOType.Output, ApplicationMode.Filler, 0, 0);               // EMD = Entleermodus
          }
+
+
+        private void CreateList()
+        {
+            items.Add(ReadWeightMemDay_ID);
+            items.Add(ReadWeightMemMonth_ID);
+            items.Add(ReadWeightMemYear_ID);
+            items.Add(ReadWeightMemSeqNumber_ID);
+            items.Add(ReadWeightMemGross_ID);
+            items.Add(ReadWeightMemNet_ID);
+
+            // For filler mode: 
+            items.Add(WriteWeightMemDay_ID);
+            items.Add(WriteWeightMemMonth_ID);
+            items.Add(WriteWeightMemYear_ID);
+            items.Add(WriteWeightMemSeqNumber_ID);
+            items.Add(WriteWeightMemGross_ID);
+            items.Add(WriteWeightMemNet_ID);
+
+            // region ID Commands : Maintenance - Calibration
+
+            items.Add(Ldw_dead_weight);              // LDW = Nullpunkt
+            items.Add(Lwt_nominal_value);              // LWT = Nennwert
+            items.Add(Lft_scale_calibration_weight);   // LFT = LFT scale calibration weight
+
+            // region ID commands for process data
+            items.Add(Net_value);
+            items.Add(Gross_value);
+            items.Add(Zero_value);
+
+            items.Add(Weighing_device_1_weight_status);
+
+            items.Add(Limit_status);                   // data word = 4 ; length = 2 ; offset = 2;
+            items.Add(Unit_prefix_fixed_parameter);    // data word = 5 ; length = 2 ; offset = 7;
+
+            items.Add(Application_mode);               // data word = 5 ; length = 2 ; offset = 0;
+            items.Add(Decimals);                       // data word = 5 ; length = 3 ; offset = 4;
+            items.Add(Status);          // data word = 5 ; length = 1 ; offset = 15;
+
+            // region ID commands for standard mode
+            items.Add(Status_digital_input_1);    // IS1
+            items.Add(Status_digital_input_2);    // IS2
+            items.Add(Status_digital_input_3);    // IS3
+            items.Add(Status_digital_input_4);    // IS4
+
+            items.Add(Status_digital_output_1);   // OS1
+            items.Add(Status_digital_output_2);   // OS2
+            items.Add(Status_digital_output_3);   // OS3
+            items.Add(Status_digital_output_4);   // OS4
+
+            items.Add(Limit_value);   // LVS , standard
+            items.Add(Tare_value);  // manual tare value
+
+            items.Add(LimitValue1Input); // = Grenzwertüberwachung 
+            items.Add(LimitValue1Mode);
+            items.Add(LimitValue1ActivationLevelLowerBandLimit);        // = Einschaltpegel
+            items.Add(LimitValue1HysteresisBandHeight);       // = Ausschaltpegel
+
+            items.Add(LimitValue2Source);
+            items.Add(LimitValue2Mode);
+            items.Add(LimitValue2ActivationLevelLowerBandLimit);
+            items.Add(LimitValue2HysteresisBandHeight);
+
+            items.Add(LimitValue3Source);
+            items.Add(LimitValue3Mode);
+            items.Add(LimitValue3ActivationLevelLowerBandLimit);
+            items.Add(LimitValue3HysteresisBandHeight);
+
+            items.Add(LimitValue4Source);
+            items.Add(LimitValue4Mode);
+            items.Add(LimitValue4ActivationLevelLowerBandLimit);
+            items.Add(LimitValue4HysteresisBandHeight);
+
+        // region ID commands for filler data:
+
+            items.Add(CoarseFlow);               // data input word 8, bit .0, application mode=filler
+            items.Add(FineFlow);                 // data input word 8, bit .1, application mode=filler
+            items.Add(Ready);                    // data input word 8, bit .2, application mode=filler
+            items.Add(ReDosing);                 // data input word 8, bit .3, application mode=filler; RDS = Nachdosieren
+            items.Add(Emptying);                 // data input word 8, bit .4, application mode=filler
+            items.Add(FlowError);                // data input word 8, bit .5, application mode=filler
+            items.Add(Alarm);                    // data input word 8, bit .6, application mode=filler
+            items.Add(AdcOverUnderload);         // data input word 8, bit .7, application mode=filler
+            items.Add(MaximalDosingTimeInput);   // data input word 8, bit .8, application mode=filler
+            items.Add(LegalForTradeOperation);   // data input word 8, bit .9, application mode=filler
+            items.Add(ToleranceErrorPlus);       // data input word 8, bit .10, application mode=filler
+            items.Add(ToleranceErrorMinus);      // data input word 8, bit .11, application mode=filler
+            items.Add(StatusInput1);             // data input word 8, bit .14, application mode=filler
+            items.Add(GeneralScaleError);        // data input word 8, bit .15, application mode=filler
+
+            items.Add(TotalWeight);             // data input word 18, application mode=filler
+            items.Add(Dosing_time);             // DST = Dosieristzeit
+            items.Add(Coarse_flow_time);        // CFT = Grobstromzeit
+            items.Add(CurrentFineFlowTime);     // data input word 26, application mode=filler; FFT = Feinstromzeit
+            items.Add(ParameterSetProduct);     // data input word 27, application mode=filler
+
+            items.Add(TargetFillingWeight);        // data output word 10, application mode=filler
+            items.Add(Residual_flow_time);          // RFT = Nachstromzeit
+            //items.Add(Reference_value_dosing);     // FWT = Sollwert dosieren = Target filling weight
+            items.Add(Coarse_flow_cut_off_point);  // CFD = Grobstromabschaltpunkt
+            items.Add(Fine_flow_cut_off_point);    // FFD = Feinstromabschaltpunkt
+
+            items.Add(Minimum_fine_flow);          // FFM = Minimaler Feinstromanteil
+            items.Add(Optimization);               // OSN = Optimierung
+            items.Add(Maximal_dosing_time);        // MDT = Maximale Dosierzeit
+            items.Add(Run_start_dosing);          // RUN = Start Dosieren
+
+            items.Add(Lockout_time_coarse_flow);   // LTC = Sperrzeit Grobstrom
+            items.Add(Lockout_time_fine_flow);     // LTF = Sperrzeit Feinstrom
+            items.Add(Tare_mode);                  // TMD = Tariermodus
+            items.Add(Upper_tolerance_limit);      // UTL = Obere Toleranz
+
+            items.Add(Lower_tolerance_limit);      // LTL = Untere Toleranz
+            items.Add(Minimum_start_weight);       // MSW = Minimum Startgewicht
+            items.Add(Empty_weight);
+            items.Add(Tare_delay);                  // TAD = Tarierverzögerung
+
+            items.Add(Coarse_flow_monitoring_time); // CBT = Überwachungszeit Grobstrom
+            items.Add(Coarse_flow_monitoring);      // CBK = Füllstromüberwachung Grobstrom
+            items.Add(Fine_flow_monitoring);        // FBK = Füllstromüberwachung Feinstrom
+            items.Add(Fine_flow_monitoring_time);   // FBT = Überwachungszeit Feinstrom
+
+            items.Add(Delay_time_after_fine_flow);
+            items.Add(Activation_time_after_fine_flow);
+
+            items.Add(Systematic_difference);       // SYD = Systematische Differenz
+            items.Add(DownwardsDosing);             // data output word 42, application mode=filler
+            items.Add(Valve_control);               // VCT = Ventilsteuerung
+            items.Add(Emptying_mode);               // EMD = Entleermodus
+        }
 
         // region ID Commands : Memory - day, month, year, seqNumber, gross, net
 
@@ -208,17 +352,24 @@ namespace HBM.Weighing.API.WTX.Modbus
         public ModbusCommand Net_value { get; private set; }
         public ModbusCommand Gross_value { get; private set; }
         public ModbusCommand Zero_value { get; private set; }
-
         public ModbusCommand Weighing_device_1_weight_status { get; private set; }
 
-        public ModbusCommand Limit_status { get; private set; }                   // data word = 4 ; length = 2 ; offset = 2;
-        public ModbusCommand Unit_prefix_fixed_parameter { get; private set; }    // data word = 5 ; length = 2 ; offset = 7;
-
-        public ModbusCommand Application_mode { get; private set; }               // data word = 5 ; length = 2 ; offset = 0;
-        public ModbusCommand Decimals { get; private set; }                       // data word = 5 ; length = 3 ; offset = 4;
-        public ModbusCommand Scale_command_status { get; private set; }           // data word = 5 ; length = 1 ; offset = 15;
-
-        public ModbusCommand Scale_command { get; private set; }
+        public ModbusCommand GeneralWeightError { get; private set; }
+        public ModbusCommand ScaleAlarmTriggered { get; private set; }
+        public ModbusCommand WeightMoving { get; private set; }
+        public ModbusCommand ScaleSealIsOpen { get; private set; }
+        public ModbusCommand ManualTare { get; private set; }
+        public ModbusCommand WeightType { get; private set; }
+        public ModbusCommand ScaleRange { get; private set; }
+        public ModbusCommand ZeroRequired { get; private set; }
+        public ModbusCommand WeightinCenterOfZero { get; private set; }
+        public ModbusCommand WeightinZeroRange { get; private set; }
+        public ModbusCommand Decimals { get; private set; }
+        public ModbusCommand Handshake { get; private set; }
+        public ModbusCommand Limit_status { get; private set; }             
+        public ModbusCommand Unit_prefix_fixed_parameter { get; private set; }   
+        public ModbusCommand Application_mode { get; private set; }            
+        public ModbusCommand Status { get; private set; }    
 
         // region ID commands for standard mode
         public ModbusCommand Status_digital_input_1 { get; private set; }    // IS1
@@ -235,25 +386,25 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         public ModbusCommand Tare_value { get; private set; }  // manual tare value
 
-        public ModbusCommand Limit_value_monitoring_liv11 { get; private set; } // = Grenzwertüberwachung 
-        public ModbusCommand Signal_source_liv12 { get; private set; }
-        public ModbusCommand Switch_on_level_liv13 { get; private set; }        // = Einschaltpegel
-        public ModbusCommand Switch_off_level_liv14 { get; private set; }       // = Ausschaltpegel
+        public ModbusCommand LimitValue1Input { get; private set; } // = Grenzwertüberwachung 
+        public ModbusCommand LimitValue1Mode { get; private set; }
+        public ModbusCommand LimitValue1ActivationLevelLowerBandLimit { get; private set; }        // = Einschaltpegel
+        public ModbusCommand LimitValue1HysteresisBandHeight { get; private set; }       // = Ausschaltpegel
 
-        public ModbusCommand Limit_value_monitoring_liv21 { get; private set; }
-        public ModbusCommand Signal_source_liv22 { get; private set; }
-        public ModbusCommand Switch_on_level_liv23 { get; private set; }
-        public ModbusCommand Switch_off_level_liv24 { get; private set; }
+        public ModbusCommand LimitValue2Source { get; private set; }
+        public ModbusCommand LimitValue2Mode { get; private set; }
+        public ModbusCommand LimitValue2ActivationLevelLowerBandLimit { get; private set; }
+        public ModbusCommand LimitValue2HysteresisBandHeight { get; private set; }
 
-        public ModbusCommand Limit_value_monitoring_liv31 { get; private set; }
-        public ModbusCommand Signal_source_liv32 { get; private set; }
-        public ModbusCommand Switch_on_level_liv33 { get; private set; }
-        public ModbusCommand Switch_off_level_liv34 { get; private set; }
+        public ModbusCommand LimitValue3Source { get; private set; }
+        public ModbusCommand LimitValue3Mode { get; private set; }
+        public ModbusCommand LimitValue3ActivationLevelLowerBandLimit { get; private set; }
+        public ModbusCommand LimitValue3HysteresisBandHeight { get; private set; }
 
-        public ModbusCommand Limit_value_monitoring_liv41 { get; private set; }
-        public ModbusCommand Signal_source_liv42 { get; private set; }
-        public ModbusCommand Switch_on_level_liv43  { get; private set; }
-        public ModbusCommand Switch_off_level_liv44 { get; private set; }
+        public ModbusCommand LimitValue4Source { get; private set; }
+        public ModbusCommand LimitValue4Mode { get; private set; }
+        public ModbusCommand LimitValue4ActivationLevelLowerBandLimit { get; private set; }
+        public ModbusCommand LimitValue4HysteresisBandHeight { get; private set; }
 
         // region ID commands for filler data
 

--- a/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
@@ -252,39 +252,39 @@ namespace HBM.Weighing.API.WTX.Modbus
             {
 
                 case DataType.U08:
-                    _master.WriteSingleRegister(0, (ushort)Convert.ToInt32(ModbusFrame.PathIndex), (ushort)value);
+                    _master.WriteSingleRegister(0, (ushort)Convert.ToInt32(ModbusFrame.Register), (ushort)value);
                     break;
 
                 case DataType.Int16:
                     _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
                     _dataToWrite[1] = (ushort)(value & 0x0000ffff);
 
-                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.PathIndex), _dataToWrite);
+                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.Register), _dataToWrite);
                     break;
                 case DataType.U16:
                     _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
                     _dataToWrite[1] = (ushort)(value & 0x0000ffff);
 
-                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.PathIndex), _dataToWrite);
+                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.Register), _dataToWrite);
                     break;
 
                 case DataType.U32:
                     _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
                     _dataToWrite[1] = (ushort)(value & 0x0000ffff);
 
-                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.PathIndex), _dataToWrite);
+                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.Register), _dataToWrite);
                     break;
                 case DataType.Int32:
                     _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
                     _dataToWrite[1] = (ushort)(value & 0x0000ffff);
 
-                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.PathIndex), _dataToWrite);
+                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.Register), _dataToWrite);
                     break;
                 case DataType.S32:
                     _dataToWrite[0] = (ushort)((value & 0xffff0000) >> 16);
                     _dataToWrite[1] = (ushort)(value & 0x0000ffff);
 
-                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.PathIndex), _dataToWrite);
+                    _master.WriteMultipleRegisters(0, (ushort)Convert.ToInt32(ModbusFrame.Register), _dataToWrite);
                     break;
             }
         }
@@ -327,101 +327,100 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private void CreateDictionary()
         {
-            _dataIntegerBuffer.Add(_commands.Net_value.PathIndex+ Convert.ToInt32(_commands.Net_value.IO).ToString() + _commands.Net_value.BitLength.ToString()+_commands.Net_value.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Gross_value.PathIndex + Convert.ToInt32(_commands.Gross_value.IO).ToString() + _commands.Gross_value.BitLength.ToString() + _commands.Gross_value.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Weighing_device_1_weight_status.PathIndex + Convert.ToInt32(_commands.Weighing_device_1_weight_status.IO).ToString() + _commands.Weighing_device_1_weight_status.BitLength.ToString() + _commands.Weighing_device_1_weight_status.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Unit_prefix_fixed_parameter.PathIndex + Convert.ToInt32(_commands.Unit_prefix_fixed_parameter.IO).ToString() + _commands.Unit_prefix_fixed_parameter.BitLength.ToString() + _commands.Unit_prefix_fixed_parameter.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Net_value.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Gross_value.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Weighing_device_1_weight_status.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Unit_prefix_fixed_parameter.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Fine_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Fine_flow_cut_off_point.IO).ToString() + _commands.Fine_flow_cut_off_point.BitLength.ToString() + _commands.Fine_flow_cut_off_point.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Coarse_flow_cut_off_point.IO).ToString() + _commands.Coarse_flow_cut_off_point.BitLength.ToString() + _commands.Coarse_flow_cut_off_point.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Decimals.PathIndex + Convert.ToInt32(_commands.Decimals.IO).ToString() + _commands.Decimals.BitLength.ToString() + _commands.Decimals.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Application_mode.PathIndex + Convert.ToInt32(_commands.Application_mode.IO).ToString() + _commands.Application_mode.BitLength.ToString() + _commands.Application_mode.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Scale_command_status.PathIndex + Convert.ToInt32(_commands.Scale_command_status.IO).ToString() + _commands.Scale_command_status.BitLength.ToString() + _commands.Scale_command_status.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Fine_flow_cut_off_point.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_cut_off_point.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Decimals.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Application_mode.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Status_digital_input_1.PathIndex + Convert.ToInt32(_commands.Status_digital_input_1.IO).ToString() + _commands.Status_digital_input_1.BitLength.ToString() + _commands.Status_digital_input_1.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Status_digital_input_2.PathIndex + Convert.ToInt32(_commands.Status_digital_input_2.IO).ToString() + _commands.Status_digital_input_2.BitLength.ToString() + _commands.Status_digital_input_2.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Status_digital_input_3.PathIndex + Convert.ToInt32(_commands.Status_digital_input_3.IO).ToString() + _commands.Status_digital_input_3.BitLength.ToString() + _commands.Status_digital_input_3.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Status_digital_input_4.PathIndex + Convert.ToInt32(_commands.Status_digital_input_4.IO).ToString() + _commands.Status_digital_input_4.BitLength.ToString() + _commands.Status_digital_input_4.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_input_1.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_input_2.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_input_3.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_input_4.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Status_digital_output_1.PathIndex + Convert.ToInt32(_commands.Status_digital_output_1.IO).ToString() + _commands.Status_digital_output_1.BitLength.ToString() + _commands.Status_digital_output_1.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Status_digital_output_2.PathIndex + Convert.ToInt32(_commands.Status_digital_output_2.IO).ToString() + _commands.Status_digital_output_2.BitLength.ToString() + _commands.Status_digital_output_2.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Status_digital_output_3.PathIndex + Convert.ToInt32(_commands.Status_digital_output_3.IO).ToString() + _commands.Status_digital_output_3.BitLength.ToString() + _commands.Status_digital_output_3.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Status_digital_output_4.PathIndex + Convert.ToInt32(_commands.Status_digital_output_4.IO).ToString() + _commands.Status_digital_output_4.BitLength.ToString() + _commands.Status_digital_output_4.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_output_1.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_output_2.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_output_3.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_output_4.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value.PathIndex + Convert.ToInt32(_commands.Limit_value.IO).ToString() + _commands.Limit_value.BitLength.ToString() + _commands.Limit_value.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv11.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv11.IO).ToString() + _commands.Limit_value_monitoring_liv11.BitLength.ToString() + _commands.Limit_value_monitoring_liv11.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv12.PathIndex + Convert.ToInt32(_commands.Signal_source_liv12.IO).ToString() + _commands.Signal_source_liv12.BitLength.ToString() + _commands.Signal_source_liv12.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv13.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv13.IO).ToString() + _commands.Switch_on_level_liv13.BitLength.ToString() + _commands.Switch_on_level_liv13.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv14.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv14.IO).ToString() + _commands.Switch_off_level_liv14.BitLength.ToString() + _commands.Switch_off_level_liv14.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Limit_value.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue1Input.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue1Mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue1ActivationLevelLowerBandLimit.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue1HysteresisBandHeight.Path, 0);
             
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv21.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv21.IO).ToString() + _commands.Limit_value_monitoring_liv21.BitLength.ToString() + _commands.Limit_value_monitoring_liv21.BitIndex.ToString(), 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv22.PathIndex + Convert.ToInt32(_commands.Signal_source_liv22.IO).ToString() + _commands.Signal_source_liv22.BitLength.ToString() + _commands.Signal_source_liv22.BitIndex.ToString(), 0);
-            /*
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv23.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv23.IO).ToString() + _commands.Switch_on_level_liv23.BitLength.ToString() + _commands.Switch_on_level_liv23.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv24.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv24.IO).ToString() + _commands.Switch_off_level_liv24.BitLength.ToString() + _commands.Switch_off_level_liv24.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue2Source.Path, 0); ;
+            _dataIntegerBuffer.Add(_commands.LimitValue2Mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue2ActivationLevelLowerBandLimit.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue2HysteresisBandHeight.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv31.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv31.IO).ToString() + _commands.Limit_value_monitoring_liv31.BitLength.ToString() + _commands.Limit_value_monitoring_liv31.BitIndex.ToString(), 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv32.PathIndex + Convert.ToInt32(_commands.Signal_source_liv32.IO).ToString() + _commands.Signal_source_liv32.BitLength.ToString() + _commands.Signal_source_liv32.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv33.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv33.IO).ToString() + _commands.Switch_on_level_liv33.BitLength.ToString() + _commands.Switch_on_level_liv33.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv34.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv34.IO).ToString() + _commands.Switch_off_level_liv34.BitLength.ToString() + _commands.Switch_off_level_liv34.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue3Source.Path, 0); ;
+            _dataIntegerBuffer.Add(_commands.LimitValue3Mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue3ActivationLevelLowerBandLimit.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue3HysteresisBandHeight.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv41.PathIndex + Convert.ToInt32(_commands.Limit_value_monitoring_liv41.IO).ToString() + _commands.Limit_value_monitoring_liv41.BitLength.ToString() + _commands.Limit_value_monitoring_liv41.BitIndex.ToString(), 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv42.PathIndex + Convert.ToInt32(_commands.Signal_source_liv42.IO).ToString() + _commands.Signal_source_liv42.BitLength.ToString() + _commands.Signal_source_liv42.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv43.PathIndex + Convert.ToInt32(_commands.Switch_on_level_liv43.IO).ToString() + _commands.Switch_on_level_liv43.BitLength.ToString() + _commands.Switch_on_level_liv43.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv44.PathIndex + Convert.ToInt32(_commands.Switch_off_level_liv44.IO).ToString() + _commands.Switch_off_level_liv44.BitLength.ToString() + _commands.Switch_off_level_liv44.BitIndex.ToString(), 0);
-            */
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemDay_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemDay_ID.IO).ToString() + _commands.ReadWeightMemDay_ID.BitLength.ToString() + _commands.ReadWeightMemDay_ID.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemMonth_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemMonth_ID.IO).ToString() + _commands.ReadWeightMemMonth_ID.BitLength.ToString() + _commands.ReadWeightMemMonth_ID.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemYear_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemYear_ID.IO).ToString() + _commands.ReadWeightMemYear_ID.BitLength.ToString() + _commands.ReadWeightMemYear_ID.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemSeqNumber_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemSeqNumber_ID.IO).ToString() + _commands.ReadWeightMemSeqNumber_ID.BitLength.ToString() + _commands.ReadWeightMemSeqNumber_ID.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemGross_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemGross_ID.IO).ToString() + _commands.ReadWeightMemGross_ID.BitLength.ToString() + _commands.ReadWeightMemGross_ID.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemNet_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemNet_ID.IO).ToString() + _commands.ReadWeightMemNet_ID.BitLength.ToString() + _commands.ReadWeightMemNet_ID.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue4Source.Path, 0); ;
+            _dataIntegerBuffer.Add(_commands.LimitValue4Mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue4ActivationLevelLowerBandLimit.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LimitValue4HysteresisBandHeight.Path, 0);
 
-            //_dataIntegerBuffer.Add(_commands.Residual_flow_time.PathIndex + Convert.ToInt32(_commands.Residual_flow_time.IO).ToString() + _commands.Residual_flow_time.BitLength.ToString() + _commands.Residual_flow_time.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Minimum_fine_flow.PathIndex + Convert.ToInt32(_commands.Minimum_fine_flow.IO).ToString() + _commands.Minimum_fine_flow.BitLength.ToString() + _commands.Minimum_fine_flow.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Optimization.PathIndex + Convert.ToInt32(_commands.Optimization.IO).ToString() + _commands.Optimization.BitLength.ToString() + _commands.Optimization.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Tare_mode.PathIndex + Convert.ToInt32(_commands.Tare_mode.IO).ToString() + _commands.Tare_mode.BitLength.ToString() + _commands.Tare_mode.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Minimum_start_weight.PathIndex + Convert.ToInt32(_commands.Minimum_start_weight.IO).ToString() + _commands.Minimum_start_weight.BitLength.ToString() + _commands.Minimum_start_weight.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Tare_delay.PathIndex + Convert.ToInt32(_commands.Tare_delay.IO).ToString() + _commands.Tare_delay.BitLength.ToString() + _commands.Tare_delay.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring_time.PathIndex + Convert.ToInt32(_commands.Coarse_flow_monitoring_time.IO).ToString() + _commands.Coarse_flow_monitoring_time.BitLength.ToString() + _commands.Coarse_flow_monitoring_time.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring_time.PathIndex + Convert.ToInt32(_commands.Fine_flow_monitoring_time.IO).ToString() + _commands.Fine_flow_monitoring_time.BitLength.ToString() + _commands.Fine_flow_monitoring_time.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Systematic_difference.PathIndex + Convert.ToInt32(_commands.Systematic_difference.IO).ToString() + _commands.Systematic_difference.BitLength.ToString() + _commands.Systematic_difference.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Valve_control.PathIndex + Convert.ToInt32(_commands.Valve_control.IO).ToString() + _commands.Valve_control.BitLength.ToString() + _commands.Valve_control.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.AdcOverUnderload.PathIndex + Convert.ToInt32(_commands.AdcOverUnderload.IO).ToString() + _commands.AdcOverUnderload.BitLength.ToString() + _commands.AdcOverUnderload.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.LegalForTradeOperation.PathIndex + Convert.ToInt32(_commands.LegalForTradeOperation.IO).ToString() + _commands.LegalForTradeOperation.BitLength.ToString() + _commands.LegalForTradeOperation.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemDay_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemMonth_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemYear_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemSeqNumber_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemGross_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemNet_ID.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.StatusInput1.PathIndex + Convert.ToInt32(_commands.StatusInput1.IO).ToString() + _commands.StatusInput1.BitLength.ToString() + _commands.StatusInput1.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.GeneralScaleError.PathIndex + Convert.ToInt32(_commands.GeneralScaleError.IO).ToString() + _commands.GeneralScaleError.BitLength.ToString() + _commands.GeneralScaleError.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.CoarseFlow.PathIndex + Convert.ToInt32(_commands.CoarseFlow.IO).ToString() + _commands.CoarseFlow.BitLength.ToString() + _commands.CoarseFlow.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.FineFlow.PathIndex + Convert.ToInt32(_commands.FineFlow.IO).ToString() + _commands.FineFlow.BitLength.ToString() + _commands.FineFlow.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Ready.PathIndex + Convert.ToInt32(_commands.Ready.IO).ToString() + _commands.Ready.BitLength.ToString() + _commands.Ready.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ReDosing.PathIndex + Convert.ToInt32(_commands.ReDosing.IO).ToString() + _commands.ReDosing.BitLength.ToString() + _commands.ReDosing.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Emptying.PathIndex + Convert.ToInt32(_commands.Emptying.IO).ToString() + _commands.Emptying.BitLength.ToString() + _commands.Emptying.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.FlowError.PathIndex + Convert.ToInt32(_commands.FlowError.IO).ToString() + _commands.FlowError.BitLength.ToString() + _commands.FlowError.BitIndex.ToString(), 0);
+            //_dataIntegerBuffer.Add(_commands.Residual_flow_time.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Alarm.PathIndex + Convert.ToInt32(_commands.Alarm.IO).ToString() + _commands.Alarm.BitLength.ToString() + _commands.Alarm.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ToleranceErrorPlus.PathIndex + Convert.ToInt32(_commands.ToleranceErrorPlus.IO).ToString() + _commands.ToleranceErrorPlus.BitLength.ToString() + _commands.ToleranceErrorPlus.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ToleranceErrorMinus.PathIndex + Convert.ToInt32(_commands.ToleranceErrorMinus.IO).ToString() + _commands.ToleranceErrorMinus.BitLength.ToString() + _commands.ToleranceErrorMinus.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Dosing_time.PathIndex + Convert.ToInt32(_commands.Dosing_time.IO).ToString() + _commands.Dosing_time.BitLength.ToString() + _commands.Dosing_time.BitIndex.ToString() , 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_time.PathIndex + Convert.ToInt32(_commands.Coarse_flow_time.IO).ToString() + _commands.Coarse_flow_time.BitLength.ToString() + _commands.Coarse_flow_time.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.CurrentFineFlowTime.PathIndex + Convert.ToInt32(_commands.CurrentFineFlowTime.IO).ToString() + _commands.CurrentFineFlowTime.BitLength.ToString() + _commands.CurrentFineFlowTime.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.ParameterSetProduct.PathIndex + Convert.ToInt32(_commands.ParameterSetProduct.IO).ToString() + _commands.ParameterSetProduct.BitLength.ToString() + _commands.ParameterSetProduct.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.DownwardsDosing.PathIndex + Convert.ToInt32(_commands.DownwardsDosing.IO).ToString() + _commands.DownwardsDosing.BitLength.ToString() + _commands.DownwardsDosing.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Minimum_fine_flow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Optimization.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Tare_mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Minimum_start_weight.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Tare_delay.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Systematic_difference.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Valve_control.Path, 0);
+            _dataIntegerBuffer.Add(_commands.AdcOverUnderload.Path, 0);
+            _dataIntegerBuffer.Add(_commands.LegalForTradeOperation.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.TotalWeight.PathIndex + Convert.ToInt32(_commands.TotalWeight.IO).ToString() + _commands.TotalWeight.BitLength.ToString() + _commands.TotalWeight.BitIndex.ToString(), 0);
-            //_dataIntegerBuffer.Add(_commands.TargetFillingWeight.PathIndex + Convert.ToInt32(_commands.TargetFillingWeight.IO).ToString() + _commands.TargetFillingWeight.BitLength.ToString() + _commands.TargetFillingWeight.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Run_start_dosing.PathIndex + Convert.ToInt32(_commands.Run_start_dosing.IO).ToString() + _commands.Run_start_dosing.BitLength.ToString() + _commands.Run_start_dosing.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.StatusInput1.Path, 0);
+            _dataIntegerBuffer.Add(_commands.GeneralScaleError.Path, 0);
+            _dataIntegerBuffer.Add(_commands.CoarseFlow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.FineFlow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Ready.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReDosing.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Emptying.Path, 0);
+            _dataIntegerBuffer.Add(_commands.FlowError.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring.PathIndex + Convert.ToInt32(_commands.Coarse_flow_monitoring.IO).ToString() + _commands.Coarse_flow_monitoring.BitLength.ToString() + _commands.Coarse_flow_monitoring.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring.PathIndex + Convert.ToInt32(_commands.Fine_flow_monitoring.IO).ToString() + _commands.Fine_flow_monitoring.BitLength.ToString() + _commands.Fine_flow_monitoring.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Emptying_mode.PathIndex + Convert.ToInt32(_commands.Emptying_mode.IO).ToString() + _commands.Emptying_mode.BitLength.ToString() + _commands.Emptying_mode.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Maximal_dosing_time.PathIndex + Convert.ToInt32(_commands.Maximal_dosing_time.IO).ToString() + _commands.Maximal_dosing_time.BitLength.ToString() + _commands.Maximal_dosing_time.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Alarm.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ToleranceErrorPlus.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ToleranceErrorMinus.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Dosing_time.Path , 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.CurrentFineFlowTime.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ParameterSetProduct.Path, 0);
+            _dataIntegerBuffer.Add(_commands.DownwardsDosing.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Upper_tolerance_limit.PathIndex + Convert.ToInt32(_commands.Upper_tolerance_limit.IO).ToString() + _commands.Upper_tolerance_limit.BitLength.ToString() + _commands.Upper_tolerance_limit.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Lower_tolerance_limit.PathIndex + Convert.ToInt32(_commands.Lower_tolerance_limit.IO).ToString() + _commands.Lower_tolerance_limit.BitLength.ToString() + _commands.Lower_tolerance_limit.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.TotalWeight.Path, 0);
+            _dataIntegerBuffer.Add(_commands.TargetFillingWeight.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Run_start_dosing.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Delay_time_after_fine_flow.PathIndex + Convert.ToInt32(_commands.Delay_time_after_fine_flow.IO).ToString() + _commands.Delay_time_after_fine_flow.BitLength.ToString() + _commands.Delay_time_after_fine_flow.BitIndex.ToString(), 0);
-            _dataIntegerBuffer.Add(_commands.Activation_time_after_fine_flow.PathIndex + Convert.ToInt32(_commands.Activation_time_after_fine_flow.IO).ToString() + _commands.Activation_time_after_fine_flow.BitLength.ToString() + _commands.Activation_time_after_fine_flow.BitIndex.ToString(), 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Emptying_mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Maximal_dosing_time.Path, 0);
+
+            _dataIntegerBuffer.Add(_commands.Upper_tolerance_limit.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Lower_tolerance_limit.Path, 0);
+
+            _dataIntegerBuffer.Add(_commands.Delay_time_after_fine_flow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Activation_time_after_fine_flow.Path, 0);
 
             // Undefined IDs : 
             /*
@@ -438,53 +437,47 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private void UpdateDictionary()
         {
-            _dataIntegerBuffer[_commands.Net_value.PathIndex + Convert.ToInt32(_commands.Net_value.IO).ToString() + _commands.Net_value.BitLength.ToString() + _commands.Net_value.BitIndex.ToString()] = _data[1] + (_data[0] << 16);
-            _dataIntegerBuffer[_commands.Gross_value.PathIndex + Convert.ToInt32(_commands.Gross_value.IO).ToString() + _commands.Gross_value.BitLength.ToString() + _commands.Gross_value.BitIndex.ToString()] =  _data[3] + (_data[2] << 16);
-            _dataIntegerBuffer[_commands.Weighing_device_1_weight_status.PathIndex + Convert.ToInt32(_commands.Weighing_device_1_weight_status.IO).ToString() + _commands.Weighing_device_1_weight_status.BitLength.ToString() + _commands.Weighing_device_1_weight_status.BitIndex.ToString()] = _data[4];
-            _dataIntegerBuffer[_commands.Scale_command_status.PathIndex + Convert.ToInt32(_commands.Scale_command_status.IO).ToString() + _commands.Scale_command_status.BitLength.ToString() + _commands.Scale_command_status.BitIndex.ToString()] = _data[5];                  // status -> Measured value status
-            _dataIntegerBuffer[_commands.Status_digital_input_1.PathIndex + Convert.ToInt32(_commands.Status_digital_input_1.IO).ToString() + _commands.Status_digital_input_1.BitLength.ToString() + _commands.Status_digital_input_1.BitIndex.ToString()] = _data[6];
-            _dataIntegerBuffer[_commands.Status_digital_output_1.PathIndex + Convert.ToInt32(_commands.Status_digital_output_1.IO).ToString() + _commands.Status_digital_output_1.BitLength.ToString() + _commands.Status_digital_output_1.BitIndex.ToString()] = _data[7];
-            _dataIntegerBuffer[_commands.Limit_value.PathIndex + Convert.ToInt32(_commands.Limit_value.IO).ToString() + _commands.Limit_value.BitLength.ToString() + _commands.Limit_value.BitIndex.ToString()] = _data[8];
-            _dataIntegerBuffer[_commands.Fine_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Fine_flow_cut_off_point.IO).ToString() + _commands.Fine_flow_cut_off_point.BitLength.ToString() + _commands.Fine_flow_cut_off_point.BitIndex.ToString()] = _data[20];
-            _dataIntegerBuffer[_commands.Coarse_flow_cut_off_point.PathIndex + Convert.ToInt32(_commands.Coarse_flow_cut_off_point.IO).ToString() + _commands.Coarse_flow_cut_off_point.BitLength.ToString() + _commands.Coarse_flow_cut_off_point.BitIndex.ToString()] = _data[22];
+            _dataIntegerBuffer[_commands.Net_value.Path] = _data[1] + (_data[0] << 16);
+            _dataIntegerBuffer[_commands.Gross_value.Path] =  _data[3] + (_data[2] << 16);
+            _dataIntegerBuffer[_commands.Weighing_device_1_weight_status.Path] = _data[4];
+            _dataIntegerBuffer[_commands.Status_digital_input_1.Path] = _data[6];
+            _dataIntegerBuffer[_commands.Status_digital_output_1.Path] = _data[7];
+            _dataIntegerBuffer[_commands.Limit_value.Path] = _data[8];
+            _dataIntegerBuffer[_commands.Fine_flow_cut_off_point.Path] = _data[20];
+            _dataIntegerBuffer[_commands.Coarse_flow_cut_off_point.Path] = _data[22];
 
-            _dataIntegerBuffer[_commands.Application_mode.PathIndex + Convert.ToInt32(_commands.Application_mode.IO).ToString() + _commands.Application_mode.BitLength.ToString() + _commands.Application_mode.BitIndex.ToString()] = _data[5] & 0x1;             // application mode 
-            _dataIntegerBuffer[_commands.Decimals.PathIndex + Convert.ToInt32(_commands.Decimals.IO).ToString() + _commands.Decimals.BitLength.ToString() + _commands.Decimals.BitIndex.ToString()] = (_data[5] & 0x70) >> 4;             // decimals
-            _dataIntegerBuffer[_commands.Unit_prefix_fixed_parameter.PathIndex + Convert.ToInt32(_commands.Unit_prefix_fixed_parameter.IO).ToString() + _commands.Unit_prefix_fixed_parameter.BitLength.ToString() + _commands.Unit_prefix_fixed_parameter.BitIndex.ToString()] = (_data[5] & 0x180) >> 7;    // unit
+            _dataIntegerBuffer[_commands.Application_mode.Path] = _data[5] & 0x1;             // application mode 
+            _dataIntegerBuffer[_commands.Decimals.Path] = (_data[5] & 0x70) >> 4;             // decimals
+            _dataIntegerBuffer[_commands.Unit_prefix_fixed_parameter.Path] = (_data[5] & 0x180) >> 7;    // unit
 
             
-            _dataIntegerBuffer[_commands.Coarse_flow_monitoring.PathIndex + Convert.ToInt32(_commands.Coarse_flow_monitoring.IO).ToString() + _commands.Coarse_flow_monitoring.BitLength.ToString() + _commands.Coarse_flow_monitoring.BitIndex.ToString()] = _data[8] & 0x1;           //_coarseFlow
-            _dataIntegerBuffer[_commands.Fine_flow_monitoring.PathIndex + Convert.ToInt32(_commands.Fine_flow_monitoring.IO).ToString() + _commands.Fine_flow_monitoring.BitLength.ToString() + _commands.Fine_flow_monitoring.BitIndex.ToString()] = ((_data[8] & 0x2) >> 1);  // _fineFlow
+            _dataIntegerBuffer[_commands.Coarse_flow_monitoring.Path] = _data[8] & 0x1;           //_coarseFlow
+            _dataIntegerBuffer[_commands.Fine_flow_monitoring.Path] = ((_data[8] & 0x2) >> 1);  // _fineFlow
 
-            _dataIntegerBuffer[_commands.Ready.PathIndex + Convert.ToInt32(_commands.Ready.IO).ToString() + _commands.Ready.BitLength.ToString() + _commands.Ready.BitIndex.ToString()] = ((_data[8] & 0x4) >> 2);
-            _dataIntegerBuffer[_commands.ReDosing.PathIndex + Convert.ToInt32(_commands.ReDosing.IO).ToString() + _commands.ReDosing.BitLength.ToString() + _commands.ReDosing.BitIndex.ToString()] = ((_data[8] & 0x8) >> 3);
-            _dataIntegerBuffer[_commands.Emptying_mode.PathIndex + Convert.ToInt32(_commands.Emptying_mode.IO).ToString() + _commands.Emptying_mode.BitLength.ToString() + _commands.Emptying_mode.BitIndex.ToString()] = ((_data[8] & 0x10) >> 4);
-            _dataIntegerBuffer[_commands.Maximal_dosing_time.PathIndex + Convert.ToInt32(_commands.Maximal_dosing_time.IO).ToString() + _commands.Maximal_dosing_time.BitLength.ToString() + _commands.Maximal_dosing_time.BitIndex.ToString()] = ((_data[8] & 0x100) >> 8);
-            _dataIntegerBuffer[_commands.Upper_tolerance_limit.PathIndex + Convert.ToInt32(_commands.Upper_tolerance_limit.IO).ToString() + _commands.Upper_tolerance_limit.BitLength.ToString() + _commands.Upper_tolerance_limit.BitIndex.ToString()] = ((_data[8] & 0x400) >> 10);
-            _dataIntegerBuffer[_commands.Lower_tolerance_limit.PathIndex + Convert.ToInt32(_commands.Lower_tolerance_limit.IO).ToString() + _commands.Lower_tolerance_limit.BitLength.ToString() + _commands.Lower_tolerance_limit.BitIndex.ToString()] = ((_data[8] & 0x800) >> 11);
-            _dataIntegerBuffer[_commands.StatusInput1.PathIndex + Convert.ToInt32(_commands.StatusInput1.IO).ToString() + _commands.StatusInput1.BitLength.ToString() + _commands.StatusInput1.BitIndex.ToString()] = ((_data[8] & 0x4000) >> 14);
-            _dataIntegerBuffer[_commands.LegalForTradeOperation.PathIndex + Convert.ToInt32(_commands.LegalForTradeOperation.IO).ToString() + _commands.LegalForTradeOperation.BitLength.ToString() + _commands.LegalForTradeOperation.BitIndex.ToString()] = ((_data[8] & 0x200) >> 9);
+            _dataIntegerBuffer[_commands.Ready.Path] = ((_data[8] & 0x4) >> 2);
+            _dataIntegerBuffer[_commands.ReDosing.Path] = ((_data[8] & 0x8) >> 3);
+            _dataIntegerBuffer[_commands.Emptying_mode.Path] = ((_data[8] & 0x10) >> 4);
+            _dataIntegerBuffer[_commands.Maximal_dosing_time.Path] = ((_data[8] & 0x100) >> 8);
+            _dataIntegerBuffer[_commands.Upper_tolerance_limit.Path] = ((_data[8] & 0x400) >> 10);
+            _dataIntegerBuffer[_commands.Lower_tolerance_limit.Path] = ((_data[8] & 0x800) >> 11);
+            _dataIntegerBuffer[_commands.StatusInput1.Path] = ((_data[8] & 0x4000) >> 14);
+            _dataIntegerBuffer[_commands.LegalForTradeOperation.Path] = ((_data[8] & 0x200) >> 9);
             
-            _dataIntegerBuffer[_commands.ReadWeightMemDay_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemDay_ID.IO).ToString() + _commands.ReadWeightMemDay_ID.BitLength.ToString() + _commands.ReadWeightMemDay_ID.BitIndex.ToString()]         = (_data[9]);
-            _dataIntegerBuffer[_commands.ReadWeightMemMonth_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemMonth_ID.IO).ToString() + _commands.ReadWeightMemMonth_ID.BitLength.ToString() + _commands.ReadWeightMemMonth_ID.BitIndex.ToString()] = (_data[10]);
-            _dataIntegerBuffer[_commands.ReadWeightMemYear_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemYear_ID.IO).ToString() + _commands.ReadWeightMemYear_ID.BitLength.ToString() + _commands.ReadWeightMemYear_ID.BitIndex.ToString()]     = (_data[11]);
-            _dataIntegerBuffer[_commands.ReadWeightMemSeqNumber_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemSeqNumber_ID.IO).ToString() + _commands.ReadWeightMemSeqNumber_ID.BitLength.ToString() + _commands.ReadWeightMemSeqNumber_ID.BitIndex.ToString()] = (_data[12]);
-            _dataIntegerBuffer[_commands.ReadWeightMemGross_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemGross_ID.IO).ToString() + _commands.ReadWeightMemGross_ID.BitLength.ToString() + _commands.ReadWeightMemGross_ID.BitIndex.ToString()] = (_data[13]);
-            _dataIntegerBuffer[_commands.ReadWeightMemNet_ID.PathIndex + Convert.ToInt32(_commands.ReadWeightMemNet_ID.IO).ToString() + _commands.ReadWeightMemNet_ID.BitLength.ToString() + _commands.ReadWeightMemNet_ID.BitIndex.ToString()]         = (_data[14]);
+            _dataIntegerBuffer[_commands.ReadWeightMemDay_ID.Path]         = (_data[9]);
+            _dataIntegerBuffer[_commands.ReadWeightMemMonth_ID.Path] = (_data[10]);
+            _dataIntegerBuffer[_commands.ReadWeightMemYear_ID.Path]     = (_data[11]);
+            _dataIntegerBuffer[_commands.ReadWeightMemSeqNumber_ID.Path] = (_data[12]);
+            _dataIntegerBuffer[_commands.ReadWeightMemGross_ID.Path] = (_data[13]);
+            _dataIntegerBuffer[_commands.ReadWeightMemNet_ID.Path]         = (_data[14]);
 
-            _dataIntegerBuffer[_commands.Emptying.PathIndex + Convert.ToInt32(_commands.Emptying.IO).ToString() + _commands.Emptying.BitLength.ToString() + _commands.Emptying.BitIndex.ToString()] = ((_data[8] & 0x10) >> 4);
-            _dataIntegerBuffer[_commands.FlowError.PathIndex + Convert.ToInt32(_commands.FlowError.IO).ToString() + _commands.FlowError.BitLength.ToString() + _commands.FlowError.BitIndex.ToString()] = ((_data[8] & 0x20) >> 5);
-            _dataIntegerBuffer[_commands.Alarm.PathIndex + Convert.ToInt32(_commands.Alarm.IO).ToString() + _commands.Alarm.BitLength.ToString() + _commands.Alarm.BitIndex.ToString()] = ((_data[8] & 0x40) >> 6);
-            _dataIntegerBuffer[_commands.AdcOverUnderload.PathIndex + Convert.ToInt32(_commands.AdcOverUnderload.IO).ToString() + _commands.AdcOverUnderload.BitLength.ToString() + _commands.AdcOverUnderload.BitIndex.ToString()] = ((_data[8] & 0x80) >> 7);
+            _dataIntegerBuffer[_commands.Emptying.Path] = ((_data[8] & 0x10) >> 4);
+            _dataIntegerBuffer[_commands.FlowError.Path] = ((_data[8] & 0x20) >> 5);
+            _dataIntegerBuffer[_commands.Alarm.Path] = ((_data[8] & 0x40) >> 6);
+            _dataIntegerBuffer[_commands.AdcOverUnderload.Path] = ((_data[8] & 0x80) >> 7);
 
-            _dataIntegerBuffer[_commands.StatusInput1.PathIndex + Convert.ToInt32(_commands.StatusInput1.IO).ToString() + _commands.StatusInput1.BitLength.ToString() + _commands.StatusInput1.BitIndex.ToString()] = ((_data[8] & 0x4000) >> 14);
-            _dataIntegerBuffer[_commands.GeneralScaleError.PathIndex + Convert.ToInt32(_commands.GeneralScaleError.IO).ToString() + _commands.GeneralScaleError.BitLength.ToString() + _commands.GeneralScaleError.BitIndex.ToString()] = ((_data[8] & 0x8000) >> 15);
-            _dataIntegerBuffer[_commands.TotalWeight.PathIndex + Convert.ToInt32(_commands.TotalWeight.IO).ToString() + _commands.TotalWeight.BitLength.ToString() + _commands.TotalWeight.BitIndex.ToString()] = _data[18];
-            // Filler data: Missing ID's
-            /*
-            _dataIntegerBuffer[IDCommands.] = _fillingProcessStatus = _data[9];  // Undefined
-            _dataIntegerBuffer[IDCommands.] = _numberDosingResults = _data[11];          
-            */
+            _dataIntegerBuffer[_commands.StatusInput1.Path] = ((_data[8] & 0x4000) >> 14);
+            _dataIntegerBuffer[_commands.GeneralScaleError.Path] = ((_data[8] & 0x8000) >> 15);
+            _dataIntegerBuffer[_commands.TotalWeight.Path] = _data[18];
 
             // Undefined IDs:
             /*
@@ -496,6 +489,9 @@ namespace HBM.Weighing.API.WTX.Modbus
             _dataIntegerBuffer[IDCommands.CURRENT_COARSE_FLOW_TIME] = _data[25];      // _currentCoarseFlowTime
             _dataIntegerBuffer[IDCommands.CURRENT_FINE_FLOW_TIME]   = _data[26];      // _currentFineFlowTime
             _dataIntegerBuffer[IDCommands.RANGE_SELECTION_PARAMETER] = _data[27];     // _parameterSetProduct
+
+            _dataIntegerBuffer[IDCommands.] = _fillingProcessStatus = _data[9];  // Undefined
+            _dataIntegerBuffer[IDCommands.] = _numberDosingResults = _data[11];        
             */
         }
 
@@ -635,7 +631,7 @@ public void CreateDictionary()
 
 
 /*
- *             _dataIntegerBuffer.Add(_commands.Net_value.PathIndex+ Convert.ToInt32(_commands.Net_value.IO).ToString() + _commands.Net_value.BitLength.ToString()+_commands.Net_value.BitIndex.ToString(), 0);
+ *             _dataIntegerBuffer.Add(_commands.Net_value.PathIndex+ (_commands.Net_value.DataType).ToString() + _commands.Net_value.BitLength.ToString()+_commands.Net_value.BitIndex.ToString(), 0);
         _dataCommandsBuffer.Add(_commands.Gross_value, 0);
         _dataCommandsBuffer.Add(_commands.Weighing_device_1_weight_status, 0);
         _dataCommandsBuffer.Add(_commands.Unit_prefix_fixed_parameter, 0);

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -279,105 +279,105 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private void CreateDictionary()
         {
-            _dataIntegerBuffer.Add(_commands.Net_value.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Gross_value.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Net_value.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Gross_value.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Weighing_device_1_weight_status.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Unit_prefix_fixed_parameter.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Weighing_device_1_weight_status.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Unit_prefix_fixed_parameter.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Fine_flow_cut_off_point.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_cut_off_point.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Decimals.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Application_mode.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Scale_command_status.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Fine_flow_cut_off_point.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_cut_off_point.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Decimals.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Application_mode.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Scale_command_status.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Status_digital_input_1.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_input_2.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_input_3.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_input_4.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_input_1.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Status_digital_input_2.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Status_digital_input_3.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Status_digital_input_4.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Status_digital_output_1.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_output_2.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_output_3.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_output_4.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Status_digital_output_1.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Status_digital_output_2.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Status_digital_output_3.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.Status_digital_output_4.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Limit_value.Path, 0);
             /*
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv11.PathIndex, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv12.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv13.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv14.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv11.Path, 0); ;
+            _dataIntegerBuffer.Add(_commands.Signal_source_liv12.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv13.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv14.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv21.PathIndex, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv22.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv23.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv24.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv21.Path, 0); ;
+            _dataIntegerBuffer.Add(_commands.Signal_source_liv22.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv23.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv24.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv31.PathIndex, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv32.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv33.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv34.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv31.Path, 0); ;
+            _dataIntegerBuffer.Add(_commands.Signal_source_liv32.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv33.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv34.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv41.PathIndex, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv42.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv43.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv44.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv41.Path, 0); ;
+            _dataIntegerBuffer.Add(_commands.Signal_source_liv42.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv43.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv44.Path, 0);
             */
 
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemDay_ID.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemMonth_ID.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemYear_ID.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.ReadWeightMemSeqNumber_ID.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.ReadWeightMemGross_ID.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.ReadWeightMemNet_ID.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemDay_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemMonth_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemYear_ID.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.ReadWeightMemSeqNumber_ID.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReadWeightMemGross_ID.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.ReadWeightMemNet_ID.Path, 0);
 
-            //_dataIntegerBuffer.Add(_commands.Residual_flow_time.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Minimum_fine_flow.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Optimization.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Tare_mode.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Minimum_start_weight.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Tare_delay.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring_time.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring_time.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Systematic_difference.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Valve_control.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.AdcOverUnderload.PathIndex, 0);
-            //_dataIntegerBuffer.Add(_commands.LegalForTradeOperation.PathIndex, 0);
+            //_dataIntegerBuffer.Add(_commands.Residual_flow_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Minimum_fine_flow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Optimization.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Tare_mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Minimum_start_weight.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Tare_delay.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Systematic_difference.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Valve_control.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.AdcOverUnderload.Path, 0);
+            //_dataIntegerBuffer.Add(_commands.LegalForTradeOperation.Path, 0);
             /*
-            _dataIntegerBuffer.Add(_commands.StatusInput1.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.GeneralScaleError.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.CoarseFlow.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.FineFlow.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Ready.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.ReDosing.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Emptying.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.FlowError.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.StatusInput1.Path, 0);
+            _dataIntegerBuffer.Add(_commands.GeneralScaleError.Path, 0);
+            _dataIntegerBuffer.Add(_commands.CoarseFlow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.FineFlow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Ready.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ReDosing.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Emptying.Path, 0);
+            _dataIntegerBuffer.Add(_commands.FlowError.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Alarm.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.ToleranceErrorPlus.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.ToleranceErrorMinus.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Dosing_time.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_time.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.CurrentFineFlowTime.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.ParameterSetProduct.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.DownwardsDosing.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Alarm.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ToleranceErrorPlus.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ToleranceErrorMinus.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Dosing_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_time.Path, 0);
+            _dataIntegerBuffer.Add(_commands.CurrentFineFlowTime.Path, 0);
+            _dataIntegerBuffer.Add(_commands.ParameterSetProduct.Path, 0);
+            _dataIntegerBuffer.Add(_commands.DownwardsDosing.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.TotalWeight.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.TargetFillingWeight.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Run_start_dosing.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.TotalWeight.Path, 0);
+            _dataIntegerBuffer.Add(_commands.TargetFillingWeight.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Run_start_dosing.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Emptying_mode.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Maximal_dosing_time.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Emptying_mode.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Maximal_dosing_time.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Upper_tolerance_limit.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Lower_tolerance_limit.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Upper_tolerance_limit.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Lower_tolerance_limit.Path, 0);
 
             //_dataIntegerBuffer.Add(_commands.IDCommands.RANGE_SELECTION_PARAMETER, 0);
 
-            _dataIntegerBuffer.Add(_commands.Delay_time_after_fine_flow.PathIndex, 0);
-            _dataIntegerBuffer.Add(_commands.Activation_time_after_fine_flow.PathIndex, 0);
+            _dataIntegerBuffer.Add(_commands.Delay_time_after_fine_flow.Path, 0);
+            _dataIntegerBuffer.Add(_commands.Activation_time_after_fine_flow.Path, 0);
             */
             // Undefined IDs : 
             /*
@@ -393,31 +393,30 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private void UpdateDictionary()
         {
-            _dataIntegerBuffer[_commands.Net_value.PathIndex] = _data[1] + (_data[0] << 16);
-            _dataIntegerBuffer[_commands.Gross_value.PathIndex] = _data[3] + (_data[2] << 16);
-            _dataIntegerBuffer[_commands.Weighing_device_1_weight_status.PathIndex] = _data[4];
-            _dataIntegerBuffer[_commands.Scale_command_status.PathIndex] = _data[5];                  // status -> Measured value status
-            _dataIntegerBuffer[_commands.Status_digital_input_1.PathIndex] = _data[6];
-            _dataIntegerBuffer[_commands.Status_digital_output_1.PathIndex] = _data[7];
-            _dataIntegerBuffer[_commands.Limit_value.PathIndex] = _data[8];
-            _dataIntegerBuffer[_commands.Fine_flow_cut_off_point.PathIndex] = _data[20];
-            _dataIntegerBuffer[_commands.Coarse_flow_cut_off_point.PathIndex] = _data[22];
+            _dataIntegerBuffer[_commands.Net_value.Path] = _data[1] + (_data[0] << 16);
+            _dataIntegerBuffer[_commands.Gross_value.Path] = _data[3] + (_data[2] << 16);
+            _dataIntegerBuffer[_commands.Weighing_device_1_weight_status.Path] = _data[4];
+            _dataIntegerBuffer[_commands.Status_digital_input_1.Path] = _data[6];
+            _dataIntegerBuffer[_commands.Status_digital_output_1.Path] = _data[7];
+            _dataIntegerBuffer[_commands.Limit_value.Path] = _data[8];
+            _dataIntegerBuffer[_commands.Fine_flow_cut_off_point.Path] = _data[20];
+            _dataIntegerBuffer[_commands.Coarse_flow_cut_off_point.Path] = _data[22];
 
-            _dataIntegerBuffer[_commands.Application_mode.PathIndex] = _data[5] & 0x1;             // application mode 
-            _dataIntegerBuffer[_commands.Decimals.PathIndex] = (_data[5] & 0x70) >> 4;     // decimals
-            _dataIntegerBuffer[_commands.Unit_prefix_fixed_parameter.PathIndex] = (_data[5] & 0x180) >> 7;    // unit
+            _dataIntegerBuffer[_commands.Application_mode.Path] = _data[5] & 0x1;             // application mode 
+            _dataIntegerBuffer[_commands.Decimals.Path] = (_data[5] & 0x70) >> 4;     // decimals
+            _dataIntegerBuffer[_commands.Unit_prefix_fixed_parameter.Path] = (_data[5] & 0x180) >> 7;    // unit
 
-            _dataIntegerBuffer[_commands.Coarse_flow_monitoring.PathIndex] = _data[8] & 0x1;           //_coarseFlow
-            _dataIntegerBuffer[_commands.Fine_flow_monitoring.PathIndex] = ((_data[8] & 0x2) >> 1);  // _fineFlow
+            _dataIntegerBuffer[_commands.Coarse_flow_monitoring.Path] = _data[8] & 0x1;           //_coarseFlow
+            _dataIntegerBuffer[_commands.Fine_flow_monitoring.Path] = ((_data[8] & 0x2) >> 1);  // _fineFlow
 
-            _dataIntegerBuffer[_commands.Ready.PathIndex] = ((_data[8] & 0x4) >> 2);
-            _dataIntegerBuffer[_commands.ReDosing.PathIndex] = ((_data[8] & 0x8) >> 3);
-            _dataIntegerBuffer[_commands.Emptying_mode.PathIndex] = ((_data[8] & 0x10) >> 4);
-            _dataIntegerBuffer[_commands.Maximal_dosing_time.PathIndex] = ((_data[8] & 0x100) >> 8);
-            _dataIntegerBuffer[_commands.Upper_tolerance_limit.PathIndex] = ((_data[8] & 0x400) >> 10);
-            _dataIntegerBuffer[_commands.Lower_tolerance_limit.PathIndex] = ((_data[8] & 0x800) >> 11);
-            _dataIntegerBuffer[_commands.Status_digital_input_1.PathIndex] = ((_data[8] & 0x4000) >> 14);
-            _dataIntegerBuffer[_commands.LegalForTradeOperation.PathIndex] = ((_data[8] & 0x200) >> 9);
+            _dataIntegerBuffer[_commands.Ready.Path] = ((_data[8] & 0x4) >> 2);
+            _dataIntegerBuffer[_commands.ReDosing.Path] = ((_data[8] & 0x8) >> 3);
+            _dataIntegerBuffer[_commands.Emptying_mode.Path] = ((_data[8] & 0x10) >> 4);
+            _dataIntegerBuffer[_commands.Maximal_dosing_time.Path] = ((_data[8] & 0x100) >> 8);
+            _dataIntegerBuffer[_commands.Upper_tolerance_limit.Path] = ((_data[8] & 0x400) >> 10);
+            _dataIntegerBuffer[_commands.Lower_tolerance_limit.Path] = ((_data[8] & 0x800) >> 11);
+            _dataIntegerBuffer[_commands.Status_digital_input_1.Path] = ((_data[8] & 0x4000) >> 14);
+            _dataIntegerBuffer[_commands.LegalForTradeOperation.Path] = ((_data[8] & 0x200) >> 9);
 
             /*
             _dataIntegerBuffer[IDCommands.DOSING_RESULT]      = _data[12];
@@ -430,21 +429,21 @@ namespace HBM.Weighing.API.WTX.Modbus
             _dataIntegerBuffer[IDCommands.RANGE_SELECTION_PARAMETER] = _data[27];     // _parameterSetProduct
             */
 
-            _dataIntegerBuffer[_commands.ReadWeightMemDay_ID.PathIndex] = (_data[9]);   // = weightMemDay
-            _dataIntegerBuffer[_commands.ReadWeightMemMonth_ID.PathIndex] = (_data[10]);  // = weightMemMonth
-            _dataIntegerBuffer[_commands.ReadWeightMemYear_ID.PathIndex] = (_data[11]);  // = weightMemYear
-            _dataIntegerBuffer[_commands.ReadWeightMemSeqNumber_ID.PathIndex] = (_data[12]);  // = weightMemSeqNumber
-            _dataIntegerBuffer[_commands.ReadWeightMemGross_ID.PathIndex] = (_data[13]);  // = weightMemGross
-            _dataIntegerBuffer[_commands.ReadWeightMemNet_ID.PathIndex] = (_data[14]);  // = weightMemNet
+            _dataIntegerBuffer[_commands.ReadWeightMemDay_ID.Path] = (_data[9]);   // = weightMemDay
+            _dataIntegerBuffer[_commands.ReadWeightMemMonth_ID.Path] = (_data[10]);  // = weightMemMonth
+            _dataIntegerBuffer[_commands.ReadWeightMemYear_ID.Path] = (_data[11]);  // = weightMemYear
+            _dataIntegerBuffer[_commands.ReadWeightMemSeqNumber_ID.Path] = (_data[12]);  // = weightMemSeqNumber
+            _dataIntegerBuffer[_commands.ReadWeightMemGross_ID.Path] = (_data[13]);  // = weightMemGross
+            _dataIntegerBuffer[_commands.ReadWeightMemNet_ID.Path] = (_data[14]);  // = weightMemNet
 
-            _dataIntegerBuffer[_commands.Emptying.PathIndex] = ((_data[8] & 0x10) >> 4);
-            _dataIntegerBuffer[_commands.FlowError.PathIndex] = ((_data[8] & 0x20) >> 5);
-            _dataIntegerBuffer[_commands.Alarm.PathIndex] = ((_data[8] & 0x40) >> 6);
-            _dataIntegerBuffer[_commands.AdcOverUnderload.PathIndex] = ((_data[8] & 0x80) >> 7);
+            _dataIntegerBuffer[_commands.Emptying.Path] = ((_data[8] & 0x10) >> 4);
+            _dataIntegerBuffer[_commands.FlowError.Path] = ((_data[8] & 0x20) >> 5);
+            _dataIntegerBuffer[_commands.Alarm.Path] = ((_data[8] & 0x40) >> 6);
+            _dataIntegerBuffer[_commands.AdcOverUnderload.Path] = ((_data[8] & 0x80) >> 7);
 
-            _dataIntegerBuffer[_commands.StatusInput1.PathIndex] = ((_data[8] & 0x4000) >> 14);
-            _dataIntegerBuffer[_commands.GeneralScaleError.PathIndex] = ((_data[8] & 0x8000) >> 15);
-            _dataIntegerBuffer[_commands.TotalWeight.PathIndex] = _data[18];
+            _dataIntegerBuffer[_commands.StatusInput1.Path] = ((_data[8] & 0x4000) >> 14);
+            _dataIntegerBuffer[_commands.GeneralScaleError.Path] = ((_data[8] & 0x8000) >> 15);
+            _dataIntegerBuffer[_commands.TotalWeight.Path] = _data[18];
 
             // Filler data: Missing ID's
             /*


### PR DESCRIPTION
-Adding and using paths[string] from ModbusCommand for referencing the dictionary(containing data) in data classes and ModbusTcpConnection.

-Adding path & application mode(standard, checkweigher, filler) to ModbusCommand.

-Adding List to ModbusCommands for Commands.

-Naming of limit switches in DataStandardJet & in DataStandardModbus.