### PR TITLE
GetData method in data classes. Only EventArgs as eventhandler instead of DataEventArgs. JetBusCommands for weight status and limit value. ModbusCommands to static.

### DIFF
--- a/HBM.Weighing.API/Data/DataFillerExtendedJet.cs
+++ b/HBM.Weighing.API/Data/DataFillerExtendedJet.cs
@@ -117,14 +117,14 @@ namespace HBM.Weighing.API.Data
         private int _emptyWeightTolerance;
         private int _residualFlowDosingCycle;
 
-        private INetConnection _connection;
+        private JetBusConnection _connection;
         #endregion
 
         #region constructor
 
         public DataFillerExtendedJet(INetConnection Connection):base(Connection)          
         {
-            _connection = Connection;
+            _connection = (JetBusConnection) Connection;
 
             _connection.UpdateDataClasses += UpdateFillerExtendedData;
 
@@ -203,90 +203,90 @@ namespace HBM.Weighing.API.Data
         
         #region update method for the filler extended data
 
-        public void UpdateFillerExtendedData(object sender, DataEventArgs e)
+        public void UpdateFillerExtendedData(object sender, EventArgs e)
         {
-            if (e.DataDictionary[JetBusCommands.Application_mode.PathIndex] == 2 ||  e.DataDictionary[JetBusCommands.Application_mode.PathIndex] == 3) // If application mode = filler
+            if (_connection.GetDataFromDictionary(JetBusCommands.Application_mode) == 2 ||  _connection.GetDataFromDictionary(JetBusCommands.Application_mode) == 3) // If application mode = filler
             {
                 this.UpdateFillerData(this, e);
 
-                //_errorRegister = Convert.ToInt32(e.DataDictionary[JetBusCommands.ERROR_REGISTER.PathIndex]);
-                _saveAllParameters = Convert.ToInt32(e.DataDictionary[JetBusCommands.Save_all_parameters.PathIndex]);
-                _restoreAllDefaultParameters = Convert.ToInt32(e.DataDictionary[JetBusCommands.Restore_all_default_parameters.PathIndex]);
-                _vendorID = Convert.ToInt32(e.DataDictionary[JetBusCommands.Vendor_id.PathIndex]);
+                //_errorRegister = _connection.GetDataFromDictionary(JetBusCommands.ERROR_REGISTER);
+                _saveAllParameters = _connection.GetDataFromDictionary(JetBusCommands.Save_all_parameters);
+                _restoreAllDefaultParameters = _connection.GetDataFromDictionary(JetBusCommands.Restore_all_default_parameters);
+                _vendorID = _connection.GetDataFromDictionary(JetBusCommands.Vendor_id);
 
-                _productCode = Convert.ToInt32(e.DataDictionary[JetBusCommands.Product_code.PathIndex]);
-                _serialNumber = Convert.ToInt32(e.DataDictionary[JetBusCommands.Serial_number.PathIndex]);
-                _implementedProfileSpecification = Convert.ToInt32(e.DataDictionary[JetBusCommands.Implemented_profile_specification.PathIndex]);
-                //_lcCapability = Convert.ToInt32(e.DataDictionary[JetBusCommands.LC_CAPABILITY.PathIndex]);
-                _weighingDevice1UnitPrefixOutputParameter = Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_unit_prefix_output_parameter.PathIndex]);             
+                _productCode = _connection.GetDataFromDictionary(JetBusCommands.Product_code);
+                _serialNumber = _connection.GetDataFromDictionary(JetBusCommands.Serial_number);
+                _implementedProfileSpecification = _connection.GetDataFromDictionary(JetBusCommands.Implemented_profile_specification);
+                //_lcCapability = _connection.GetDataFromDictionary(JetBusCommands.LC_CAPABILITY);
+                _weighingDevice1UnitPrefixOutputParameter = _connection.GetDataFromDictionary(JetBusCommands.Weighing_device_1_unit_prefix_output_parameter);             
 
-                _weighingDevice1WeightStep = Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_step.PathIndex]);
-                _alarms = Convert.ToInt32(e.DataDictionary[JetBusCommands.Alarms.PathIndex]);
-                _weighingDevice1OutputWeight = Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_output_weight.PathIndex]);
-                _weighingDevice1Setting = Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_setting.PathIndex]);
+                _weighingDevice1WeightStep = _connection.GetDataFromDictionary(JetBusCommands.Weighing_device_1_weight_step);
+                _alarms = _connection.GetDataFromDictionary(JetBusCommands.Alarms);
+                _weighingDevice1OutputWeight = _connection.GetDataFromDictionary(JetBusCommands.Weighing_device_1_output_weight);
+                _weighingDevice1Setting = _connection.GetDataFromDictionary(JetBusCommands.Weighing_device_1_setting);
 
-                _localGravityFactor = Convert.ToInt32(e.DataDictionary[JetBusCommands.Local_gravity_factor.PathIndex]);
-                _scaleFilterSetup = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_filter_setup.PathIndex]);
-                _dataSampleRate = Convert.ToInt32(e.DataDictionary[JetBusCommands.Data_sample_rate.PathIndex]);
+                _localGravityFactor = _connection.GetDataFromDictionary(JetBusCommands.Local_gravity_factor);
+                _scaleFilterSetup = _connection.GetDataFromDictionary(JetBusCommands.Scale_filter_setup);
+                _dataSampleRate = _connection.GetDataFromDictionary(JetBusCommands.Data_sample_rate);
 
-                _filterOrderCriticallyDamped = Convert.ToInt32(e.DataDictionary[JetBusCommands.Filter_order_critically_damped.PathIndex]);
-                _cutOffFrequencyCriticallyDamped = Convert.ToInt32(e.DataDictionary[JetBusCommands.Cut_off_frequency_critically_damped.PathIndex]);
-                _filterOrderButterworth = Convert.ToInt32(e.DataDictionary[JetBusCommands.Filter_order_butterworth.PathIndex]);
-                _cutOffFrequencyButterWorth = Convert.ToInt32(e.DataDictionary[JetBusCommands.Cut_off_frequency_butterworth.PathIndex]);
-                _filterOrderBessel = Convert.ToInt32(e.DataDictionary[JetBusCommands.Filter_order_bessel.PathIndex]);
+                _filterOrderCriticallyDamped = _connection.GetDataFromDictionary(JetBusCommands.Filter_order_critically_damped);
+                _cutOffFrequencyCriticallyDamped = _connection.GetDataFromDictionary(JetBusCommands.Cut_off_frequency_critically_damped);
+                _filterOrderButterworth = _connection.GetDataFromDictionary(JetBusCommands.Filter_order_butterworth);
+                _cutOffFrequencyButterWorth = _connection.GetDataFromDictionary(JetBusCommands.Cut_off_frequency_butterworth);
+                _filterOrderBessel = _connection.GetDataFromDictionary(JetBusCommands.Filter_order_bessel);
 
-                _cutOffFrequencyBessel = Convert.ToInt32(e.DataDictionary[JetBusCommands.Cut_off_frequency_bessel.PathIndex]);
-                _scaleSupplyNominalVoltage = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_suppy_nominal_voltage.PathIndex]);
-                _scaleSupplyMinimumVoltage = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_suppy_minimum_voltage.PathIndex]);
-                _scaleSupplyMaximumVoltage = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_suppy_maximum_voltage.PathIndex]);
+                _cutOffFrequencyBessel = _connection.GetDataFromDictionary(JetBusCommands.Cut_off_frequency_bessel);
+                _scaleSupplyNominalVoltage = _connection.GetDataFromDictionary(JetBusCommands.Scale_suppy_nominal_voltage);
+                _scaleSupplyMinimumVoltage = _connection.GetDataFromDictionary(JetBusCommands.Scale_suppy_minimum_voltage);
+                _scaleSupplyMaximumVoltage = _connection.GetDataFromDictionary(JetBusCommands.Scale_suppy_maximum_voltage);
 
-                _scaleAccuracyClass = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_accuracy_class.PathIndex]);
-                _scaleMinimumDeadLoad = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_minimum_dead_load.PathIndex]);
-                _scaleMaximumCapacity = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_maximum_capacity.PathIndex]);
-                _scaleMaximumNumberVerificationInterval = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_maximum_number_of_verification_interval.PathIndex]);
-                _scaleApportionmentFactor = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_apportionment_factor.PathIndex]);
-                _scaleSafeLoadLimit = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_safe_load_limit.PathIndex]);
-                _scaleOperationNominalTemperature = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_operation_nominal_temperature.PathIndex]);
-                _scaleOperationMinimumTemperature = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_operation_minimum_temperature.PathIndex]);
-                _scaleOperationMaximumTemperature = Convert.ToInt32(e.DataDictionary[JetBusCommands.Scale_operation_maximum_temperature.PathIndex]);
+                _scaleAccuracyClass = _connection.GetDataFromDictionary(JetBusCommands.Scale_accuracy_class);
+                _scaleMinimumDeadLoad = _connection.GetDataFromDictionary(JetBusCommands.Scale_minimum_dead_load);
+                _scaleMaximumCapacity = _connection.GetDataFromDictionary(JetBusCommands.Scale_maximum_capacity);
+                _scaleMaximumNumberVerificationInterval = _connection.GetDataFromDictionary(JetBusCommands.Scale_maximum_number_of_verification_interval);
+                _scaleApportionmentFactor = _connection.GetDataFromDictionary(JetBusCommands.Scale_apportionment_factor);
+                _scaleSafeLoadLimit = _connection.GetDataFromDictionary(JetBusCommands.Scale_safe_load_limit);
+                _scaleOperationNominalTemperature = _connection.GetDataFromDictionary(JetBusCommands.Scale_operation_nominal_temperature);
+                _scaleOperationMinimumTemperature = _connection.GetDataFromDictionary(JetBusCommands.Scale_operation_minimum_temperature);
+                _scaleOperationMaximumTemperature = _connection.GetDataFromDictionary(JetBusCommands.Scale_operation_maximum_temperature);
 
-                //_scaleRelativeMinimumLoadCellVerficationInterval = e.DataDictionary[JetBusCommands.Scale_relative_minimum_load_cell_verification_interval.PathIndex];
-                _intervalRangeControl = Convert.ToInt32(e.DataDictionary[JetBusCommands.Interval_range_control.PathIndex]);
-                _multiLimit1 = Convert.ToInt32(e.DataDictionary[JetBusCommands.Multi_limit_1.PathIndex]);
-                _multiLimit2 = Convert.ToInt32(e.DataDictionary[JetBusCommands.Multi_limit_2.PathIndex]);
-                //_oimlCertificationInformation = e.DataDictionary[JetBusCommands.Oiml_certificaiton_information.PathIndex];
-                //_ntepCertificationInformation = e.DataDictionary[JetBusCommands.Ntep_certificaiton_information.PathIndex];
-                _maximumZeroingTime = Convert.ToInt32(e.DataDictionary[JetBusCommands.Maximum_zeroing_time.PathIndex]);
-                _maximumPeakValueGross = Convert.ToInt32(e.DataDictionary[JetBusCommands.Maximum_peak_value_gross.PathIndex]);
-                _minimumPeakValueGross = Convert.ToInt32(e.DataDictionary[JetBusCommands.Minimum_peak_value_gross.PathIndex]);
+                //_scaleRelativeMinimumLoadCellVerficationInterval = _connection.GetDataFromDictionary(JetBusCommands.Scale_relative_minimum_load_cell_verification_interval);
+                _intervalRangeControl = _connection.GetDataFromDictionary(JetBusCommands.Interval_range_control);
+                _multiLimit1 = _connection.GetDataFromDictionary(JetBusCommands.Multi_limit_1);
+                _multiLimit2 = _connection.GetDataFromDictionary(JetBusCommands.Multi_limit_2);
+                //_oimlCertificationInformation = _connection.GetDataFromDictionary(JetBusCommands.Oiml_certificaiton_information);
+                //_ntepCertificationInformation = _connection.GetDataFromDictionary(JetBusCommands.Ntep_certificaiton_information);
+                _maximumZeroingTime = _connection.GetDataFromDictionary(JetBusCommands.Maximum_zeroing_time);
+                _maximumPeakValueGross = _connection.GetDataFromDictionary(JetBusCommands.Maximum_peak_value_gross);
+                _minimumPeakValueGross = _connection.GetDataFromDictionary(JetBusCommands.Minimum_peak_value_gross);
 
-                _maximumPeakValue = Convert.ToInt32(e.DataDictionary[JetBusCommands.Maximum_peak_value.PathIndex]);
-                _minimumPeakValue = Convert.ToInt32(e.DataDictionary[JetBusCommands.Minimum_peak_value.PathIndex]);
-                _weightMovingDetection = Convert.ToInt32(e.DataDictionary[JetBusCommands.Weight_moving_detection.PathIndex]);
-                //_deviceAddress = e.DataDictionary[JetBusCommands.Device_address.PathIndex];
-                //_hardwareVersion = e.DataDictionary[JetBusCommands.Hardware_version.PathIndex];
-                //_identification = e.DataDictionary[JetBusCommands.Identification.PathIndex];
+                _maximumPeakValue = _connection.GetDataFromDictionary(JetBusCommands.Maximum_peak_value);
+                _minimumPeakValue = _connection.GetDataFromDictionary(JetBusCommands.Minimum_peak_value);
+                _weightMovingDetection = _connection.GetDataFromDictionary(JetBusCommands.Weight_moving_detection);
+                //_deviceAddress = _connection.GetDataFromDictionary(JetBusCommands.Device_address);
+                //_hardwareVersion = _connection.GetDataFromDictionary(JetBusCommands.Hardware_version);
+                //_identification = _connection.GetDataFromDictionary(JetBusCommands.Identification);
 
-                _outputScale = Convert.ToInt32(e.DataDictionary[JetBusCommands.Output_scale.PathIndex]);
-                //_firmwareDate = e.DataDictionary[JetBusCommands.Firmware_date.PathIndex];
-                _resetTrigger = Convert.ToInt32(e.DataDictionary[JetBusCommands.Reset_trigger.PathIndex]);
-                _stateDigital_IO_Extended = Convert.ToInt32(e.DataDictionary[JetBusCommands.State_digital_io_extended.PathIndex]);
+                _outputScale = _connection.GetDataFromDictionary(JetBusCommands.Output_scale);
+                //_firmwareDate = _connection.GetDataFromDictionary(JetBusCommands.Firmware_date);
+                _resetTrigger = _connection.GetDataFromDictionary(JetBusCommands.Reset_trigger);
+                _stateDigital_IO_Extended = _connection.GetDataFromDictionary(JetBusCommands.State_digital_io_extended);
 
-                //_softwareIdentification = e.DataDictionary[JetBusCommands.Software_identification.PathIndex];
-                //_softwareVersion = e.DataDictionary[JetBusCommands.Software_version.PathIndex];
-                _dateTime = Convert.ToInt32(e.DataDictionary[JetBusCommands.Date_time.PathIndex]);
+                //_softwareIdentification = _connection.GetDataFromDictionary(JetBusCommands.Software_identification);
+                //_softwareVersion = _connection.GetDataFromDictionary(JetBusCommands.Software_version);
+                _dateTime = _connection.GetDataFromDictionary(JetBusCommands.Date_time);
 
-                _breakDosing = Convert.ToInt32(e.DataDictionary[JetBusCommands.Break_dosing.PathIndex]);
-                _deleteDosingResult = Convert.ToInt32(e.DataDictionary[JetBusCommands.Delete_dosing_result.PathIndex]);
-                _materialStreamLastDosing = Convert.ToInt32(e.DataDictionary[JetBusCommands.Material_stream_last_dosing.PathIndex]);
-                _sum = Convert.ToInt32(e.DataDictionary[JetBusCommands.Sum.PathIndex]);
-                _specialDosingFunctions = Convert.ToInt32(e.DataDictionary[JetBusCommands.Special_dosing_functions.PathIndex]);
-                _dischargeTime = Convert.ToInt32(e.DataDictionary[JetBusCommands.Discharge_time.PathIndex]);
-                _exceedingWeightBreak = Convert.ToInt32(e.DataDictionary[JetBusCommands.Exceeding_weight_break.PathIndex]);
-                _delay1Dosing = Convert.ToInt32(e.DataDictionary[JetBusCommands.Delay1_dosing.PathIndex]);
-                _delay2Dosing = Convert.ToInt32(e.DataDictionary[JetBusCommands.Delay2_dosing.PathIndex]);
-                _emptyWeightTolerance = Convert.ToInt32(e.DataDictionary[JetBusCommands.Empty_weight_tolerance.PathIndex]);
-                _residualFlowDosingCycle = Convert.ToInt32(e.DataDictionary[JetBusCommands.Residual_flow_dosing_cycle.PathIndex]);
+                _breakDosing = _connection.GetDataFromDictionary(JetBusCommands.Break_dosing);
+                _deleteDosingResult = _connection.GetDataFromDictionary(JetBusCommands.Delete_dosing_result);
+                _materialStreamLastDosing = _connection.GetDataFromDictionary(JetBusCommands.Material_stream_last_dosing);
+                _sum = _connection.GetDataFromDictionary(JetBusCommands.Sum);
+                _specialDosingFunctions = _connection.GetDataFromDictionary(JetBusCommands.Special_dosing_functions);
+                _dischargeTime = _connection.GetDataFromDictionary(JetBusCommands.Discharge_time);
+                _exceedingWeightBreak = _connection.GetDataFromDictionary(JetBusCommands.Exceeding_weight_break);
+                _delay1Dosing = _connection.GetDataFromDictionary(JetBusCommands.Delay1_dosing);
+                _delay2Dosing = _connection.GetDataFromDictionary(JetBusCommands.Delay2_dosing);
+                _emptyWeightTolerance = _connection.GetDataFromDictionary(JetBusCommands.Empty_weight_tolerance);
+                _residualFlowDosingCycle = _connection.GetDataFromDictionary(JetBusCommands.Residual_flow_dosing_cycle);
             }
         }
         #endregion

--- a/HBM.Weighing.API/Data/DataFillerJet.cs
+++ b/HBM.Weighing.API/Data/DataFillerJet.cs
@@ -117,14 +117,14 @@ namespace HBM.Weighing.API.Data
         private int _valveControl;
         private int _emptyingMode;
 
-        private INetConnection _connection;       
+        private JetBusConnection _connection;       
         #endregion
 
         #region contructor
 
         public DataFillerJet(INetConnection Connection) : base()
         {
-            _connection = Connection;
+            _connection = (JetBusConnection) Connection;
            
             _connection.UpdateDataClasses += UpdateFillerData;
             
@@ -201,44 +201,44 @@ namespace HBM.Weighing.API.Data
 
         #region Update methods for the filler mode
 
-        public void UpdateFillerData(object sender, DataEventArgs e)
+        public void UpdateFillerData(object sender, EventArgs e)
         {
-            if (e.DataDictionary[JetBusCommands.Application_mode.PathIndex] == 2 || e.DataDictionary[JetBusCommands.Application_mode.PathIndex] == 3)  // If application mode = filler
+            if (_connection.GetDataFromDictionary(JetBusCommands.Application_mode) == 2 || _connection.GetDataFromDictionary(JetBusCommands.Application_mode) == 3)  // If application mode = filler
             {             
                 // Via Modbus and Jetbus IDs: 
-                _maxDosingTime = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Maximal_dosing_time).PathIndex]);
-                _meanValueDosingResults = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Mean_value_dosing_results).PathIndex]);
-                _standardDeviation = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Standard_deviation).PathIndex]);
-                _fineFlowCutOffPoint = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Fine_flow_cut_off_point).PathIndex]);
-                _coarseFlowCutOffPoint = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Coarse_flow_cut_off_point).PathIndex]);
+                _maxDosingTime = _connection.GetDataFromDictionary(JetBusCommands.Maximal_dosing_time);
+                _meanValueDosingResults = _connection.GetDataFromDictionary(JetBusCommands.Mean_value_dosing_results);
+                _standardDeviation = _connection.GetDataFromDictionary(JetBusCommands.Standard_deviation);
+                _fineFlowCutOffPoint = _connection.GetDataFromDictionary(JetBusCommands.Fine_flow_cut_off_point);
+                _coarseFlowCutOffPoint = _connection.GetDataFromDictionary(JetBusCommands.Coarse_flow_cut_off_point);
 
-                _residualFlowTime = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Residual_flow_time).PathIndex]);
-                _minimumFineFlow = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Minimum_fine_flow).PathIndex]);
-                _optimizationOfCutOffPoints = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Optimization).PathIndex]);
-                _maximumDosingTime = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Maximal_dosing_time).PathIndex]);
-                _coarseLockoutTime = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Coarse_flow_time).PathIndex]);
-                _fineLockoutTime = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Fine_flow_time).PathIndex]);
-                _tareMode = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Tare_mode).PathIndex]);
+                _residualFlowTime = _connection.GetDataFromDictionary(JetBusCommands.Residual_flow_time);
+                _minimumFineFlow = _connection.GetDataFromDictionary(JetBusCommands.Minimum_fine_flow);
+                _optimizationOfCutOffPoints = _connection.GetDataFromDictionary(JetBusCommands.Optimization);
+                _maximumDosingTime = _connection.GetDataFromDictionary(JetBusCommands.Maximal_dosing_time);
+                _coarseLockoutTime = _connection.GetDataFromDictionary(JetBusCommands.Coarse_flow_time);
+                _fineLockoutTime = _connection.GetDataFromDictionary(JetBusCommands.Fine_flow_time);
+                _tareMode = _connection.GetDataFromDictionary(JetBusCommands.Tare_mode);
 
-                _upperToleranceLimit = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Upper_tolerance_limit).PathIndex]);
-                _lowerToleranceLimit = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Lower_tolerance_limit).PathIndex]);
-                _minimumStartWeight = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Minimum_start_weight).PathIndex]);
-                _emptyWeight = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Empty_weight_tolerance).PathIndex]);
-                _tareDelay = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Tare_delay).PathIndex]);
+                _upperToleranceLimit = _connection.GetDataFromDictionary(JetBusCommands.Upper_tolerance_limit);
+                _lowerToleranceLimit = _connection.GetDataFromDictionary(JetBusCommands.Lower_tolerance_limit);
+                _minimumStartWeight = _connection.GetDataFromDictionary(JetBusCommands.Minimum_start_weight);
+                _emptyWeight = _connection.GetDataFromDictionary(JetBusCommands.Empty_weight_tolerance);
+                _tareDelay = _connection.GetDataFromDictionary(JetBusCommands.Tare_delay);
 
-                _coarseFlowMonitoringTime = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Coarse_flow_monitoring_time).PathIndex]);
-                _coarseFlowMonitoring = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Coarse_flow_monitoring).PathIndex]);
-                _fineFlowMonitoring = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Fine_flow_monitoring).PathIndex]);
-                _fineFlowMonitoringTime = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Fine_flow_monitoring_time).PathIndex]); ;
+                _coarseFlowMonitoringTime = _connection.GetDataFromDictionary(JetBusCommands.Coarse_flow_monitoring_time);
+                _coarseFlowMonitoring = _connection.GetDataFromDictionary(JetBusCommands.Coarse_flow_monitoring);
+                _fineFlowMonitoring = _connection.GetDataFromDictionary(JetBusCommands.Fine_flow_monitoring);
+                _fineFlowMonitoringTime = _connection.GetDataFromDictionary(JetBusCommands.Fine_flow_monitoring_time); ;
 
-                _systematicDifference = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Systematic_difference).PathIndex]);
-                _valveControl = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Valve_control).PathIndex]);
-                _emptyingMode = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Emptying_mode).PathIndex]);
-                _delayTimeAfterFineFlow = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Delay1_dosing).PathIndex]);
-                _activationTimeAfterFineFlow = Convert.ToInt32(e.DataDictionary[(JetBusCommands.Fine_flow_phase_before_coarse_flow).PathIndex]);
+                _systematicDifference = _connection.GetDataFromDictionary(JetBusCommands.Systematic_difference);
+                _valveControl = _connection.GetDataFromDictionary(JetBusCommands.Valve_control);
+                _emptyingMode = _connection.GetDataFromDictionary(JetBusCommands.Emptying_mode);
+                _delayTimeAfterFineFlow = _connection.GetDataFromDictionary(JetBusCommands.Delay1_dosing);
+                _activationTimeAfterFineFlow = _connection.GetDataFromDictionary(JetBusCommands.Fine_flow_phase_before_coarse_flow);
                 
-                _weight_storage = Convert.ToInt16(e.DataDictionary[(JetBusCommands.Storage_weight).PathIndex]); 
-                _mode_weight_storage = Convert.ToInt16(e.DataDictionary[(JetBusCommands.Storage_weight_mode).PathIndex]);
+                _weight_storage = _connection.GetDataFromDictionary(JetBusCommands.Storage_weight); 
+                _mode_weight_storage = _connection.GetDataFromDictionary(JetBusCommands.Storage_weight_mode);
             }
         }
         #endregion

--- a/HBM.Weighing.API/Data/DataFillerModbus.cs
+++ b/HBM.Weighing.API/Data/DataFillerModbus.cs
@@ -127,7 +127,6 @@ namespace HBM.Weighing.API.Data
         private int _emptyingMode;
 
         private ModbusTcpConnection _connection;
-        private ModbusCommands _commands;
 
         #endregion
 
@@ -135,8 +134,6 @@ namespace HBM.Weighing.API.Data
 
         public DataFillerModbus(INetConnection Connection) : base()
         {
-            _commands = new ModbusCommands();
-
             _connection = (ModbusTcpConnection) Connection;
 
             _connection.UpdateDataClasses += UpdateFillerData;
@@ -214,78 +211,79 @@ namespace HBM.Weighing.API.Data
 
         #region Update methods for the filler mode
 
-        public void UpdateFillerData(object sender, DataEventArgs e)
+        public void UpdateFillerData(object sender, EventArgs e)
         {
-            if (e.DataDictionary[_commands.Application_mode.Path] == 2 || e.DataDictionary[_commands.Application_mode.Path] == 3)  // If application mode = filler
+            if (_connection.GetDataFromDictionary(ModbusCommands.Application_mode) == 2 || _connection.GetDataFromDictionary(ModbusCommands.Application_mode) == 3)  // If application mode = filler
             {
                 // Via Modbus and Jetbus IDs: 
-                _maxDosingTime = _connection.GetDataFromDictionary(_commands.Maximal_dosing_time);
-                //_meanValueDosingResults = _connection.GetDataFromDictionary(_commands.Mean_value_dosing_results);
-                //_standardDeviation = _connection.GetDataFromDictionary(_commands.Standard_deviation);
-                _fineFlowCutOffPoint = _connection.GetDataFromDictionary(_commands.Fine_flow_cut_off_point);
-                _coarseFlowCutOffPoint = _connection.GetDataFromDictionary(_commands.Coarse_flow_cut_off_point);
+                _maxDosingTime = _connection.GetDataFromDictionary(ModbusCommands.Maximal_dosing_time);
+                //_meanValueDosingResults = _connection.GetDataFromDictionary(ModbusCommands.Mean_value_dosing_results);
+                //_standardDeviation = _connection.GetDataFromDictionary(ModbusCommands.Standard_deviation);
+                _fineFlowCutOffPoint = _connection.GetDataFromDictionary(ModbusCommands.Fine_flow_cut_off_point);
+                _coarseFlowCutOffPoint = _connection.GetDataFromDictionary(ModbusCommands.Coarse_flow_cut_off_point);
 
-                //_residualFlowTime = _connection.GetDataFromDictionary(_commands.Residual_flow_time);
-                _minimumFineFlow = _connection.GetDataFromDictionary(_commands.Minimum_fine_flow);
-                _optimizationOfCutOffPoints = _connection.GetDataFromDictionary(_commands.Optimization);
-                _maximumDosingTime = _connection.GetDataFromDictionary(_commands.Maximal_dosing_time);
-                _coarseLockoutTime = _connection.GetDataFromDictionary(_commands.Coarse_flow_time);
-                _fineLockoutTime = _connection.GetDataFromDictionary(_commands.CurrentFineFlowTime);
-                _tareMode = _connection.GetDataFromDictionary(_commands.Tare_mode);
+                //_residualFlowTime = _connection.GetDataFromDictionary(ModbusCommands.Residual_flow_time);
+                _minimumFineFlow = _connection.GetDataFromDictionary(ModbusCommands.Minimum_fine_flow);
+                _optimizationOfCutOffPoints = _connection.GetDataFromDictionary(ModbusCommands.Optimization);
+                _maximumDosingTime = _connection.GetDataFromDictionary(ModbusCommands.Maximal_dosing_time);
+                _coarseLockoutTime = _connection.GetDataFromDictionary(ModbusCommands.Coarse_flow_time);
+                _fineLockoutTime = _connection.GetDataFromDictionary(ModbusCommands.CurrentFineFlowTime);
+                _tareMode = _connection.GetDataFromDictionary(ModbusCommands.Tare_mode);
 
-                _upperToleranceLimit = _connection.GetDataFromDictionary(_commands.Upper_tolerance_limit);
-                _lowerToleranceLimit = _connection.GetDataFromDictionary(_commands.Lower_tolerance_limit);
-                _minimumStartWeight = _connection.GetDataFromDictionary(_commands.Minimum_start_weight);
-                //_emptyWeight = _connection.GetDataFromDictionary(_commands.Empty_weight);
-                _tareDelay = _connection.GetDataFromDictionary(_commands.Tare_delay);
+                _upperToleranceLimit = _connection.GetDataFromDictionary(ModbusCommands.Upper_tolerance_limit);
+                _lowerToleranceLimit = _connection.GetDataFromDictionary(ModbusCommands.Lower_tolerance_limit);
+                _minimumStartWeight = _connection.GetDataFromDictionary(ModbusCommands.Minimum_start_weight);
+                //_emptyWeight = _connection.GetDataFromDictionary(ModbusCommands.Empty_weight);
+                _tareDelay = _connection.GetDataFromDictionary(ModbusCommands.Tare_delay);
 
-                _coarseFlowMonitoringTime = _connection.GetDataFromDictionary(_commands.Coarse_flow_monitoring_time);
-                _coarseFlowMonitoring = _connection.GetDataFromDictionary(_commands.Coarse_flow_monitoring);
-                _fineFlowMonitoring = _connection.GetDataFromDictionary(_commands.Fine_flow_monitoring);
-                //_fineFlowMonitoringTime = _connection.GetDataFromDictionary(_commands.Fine_flow_monitoring_time); ;
-
-                _systematicDifference = _connection.GetDataFromDictionary(_commands.Systematic_difference);
+                _coarseFlowMonitoringTime = _connection.GetDataFromDictionary(ModbusCommands.Coarse_flow_monitoring_time);
+                _coarseFlowMonitoring = _connection.GetDataFromDictionary(ModbusCommands.Coarse_flow_monitoring);
+                _fineFlowMonitoring = _connection.GetDataFromDictionary(ModbusCommands.Fine_flow_monitoring);
+                //_fineFlowMonitoringTime = _connection.GetDataFromDictionary(ModbusCommands.Fine_flow_monitoring_time); ;
+                _systematicDifference = _connection.GetDataFromDictionary(ModbusCommands.Systematic_difference);
+                
                 /*
-                _valveControl = _connection.GetDataFromDictionary(_commands.Valve_control);
-                _emptyingMode = _connection.GetDataFromDictionary(_commands.Emptying_mode);
-                _delayTimeAfterFineFlow = _connection.GetDataFromDictionary(_commands.Delay_time_after_fine_flow);
-                _activationTimeAfterFineFlow = _connection.GetDataFromDictionary(_commands.Activation_time_after_fine_flow);
-
-                _adcOverUnderload = _connection.GetDataFromDictionary(_commands.AdcOverUnderload);
-                _legalForTradeOperation = _connection.GetDataFromDictionary(_commands.LegalForTradeOperation);
-                _statusInput1 = _connection.GetDataFromDictionary(_commands.StatusInput1);
-                _generalScaleError = _connection.GetDataFromDictionary(_commands.GeneralScaleError);
-
-                _coarseFlow = _connection.GetDataFromDictionary(_commands.CoarseFlow);
-                _fineFlow = _connection.GetDataFromDictionary(_commands.FineFlow);
-                _ready = _connection.GetDataFromDictionary(_commands.Ready);
-                _reDosing = _connection.GetDataFromDictionary(_commands.ReDosing);
-
-                _emptying = _connection.GetDataFromDictionary(_commands.Emptying);
-                _flowError = _connection.GetDataFromDictionary(_commands.FlowError);
-                _alarm = _connection.GetDataFromDictionary(_commands.Alarm);
-                _toleranceErrorPlus = _connection.GetDataFromDictionary(_commands.ToleranceErrorPlus);
-
-                _toleranceErrorMinus = _connection.GetDataFromDictionary(_commands.ToleranceErrorMinus);
-                _currentDosingTime = _connection.GetDataFromDictionary(_commands.Dosing_time);
-                _currentCoarseFlowTime = _connection.GetDataFromDictionary(_commands.Coarse_flow_time);
-                _currentFineFlowTime = _connection.GetDataFromDictionary(_commands.CurrentFineFlowTime);
-
-                _parameterSetProduct = _connection.GetDataFromDictionary(_commands.ParameterSetProduct);
-                _downwardsDosing = _connection.GetDataFromDictionary(_commands.DownwardsDosing);
-                _totalWeight = _connection.GetDataFromDictionary(_commands.TotalWeight);
-
-                //_targetFillingWeight = Convert.ToInt32(e.DataDictionary[_commands.TargetFillingWeight);
-                _coarseFlowCutOffPointSet = _connection.GetDataFromDictionary(_commands.Coarse_flow_cut_off_point);
-                _fineFlowCutOffPointSet = _connection.GetDataFromDictionary(_commands.Fine_flow_cut_off_point);
-                _startWithFineFlow = _connection.GetDataFromDictionary(_commands.Run_start_dosing);  // Command 'Run_start_dosing' right
+                _valveControl = _connection.GetDataFromDictionary(ModbusCommands.Valve_control);
+                _emptyingMode = _connection.GetDataFromDictionary(ModbusCommands.Emptying_mode);
+                _delayTimeAfterFineFlow = _connection.GetDataFromDictionary(ModbusCommands.Delay_time_after_fine_flow);
+                _activationTimeAfterFineFlow = _connection.GetDataFromDictionary(ModbusCommands.Activation_time_after_fine_flow);
                 */
-                _weightMemoryDay = _connection.GetDataFromDictionary(_commands.WeightMemDayStandard);
-                _weightMemoryMonth = _connection.GetDataFromDictionary(_commands.WeightMemMonthStandard);
-                _weightMemoryYear = _connection.GetDataFromDictionary(_commands.WeightMemYearStandard);
-                _weightMemorySeqNumber = _connection.GetDataFromDictionary(_commands.WeightMemSeqNumberStandard);
-                _weightMemoryGross = _connection.GetDataFromDictionary(_commands.WeightMemGrossStandard);
-                _weightMemoryNet = _connection.GetDataFromDictionary(_commands.WeightMemNetStandard);
+
+                _adcOverUnderload = _connection.GetDataFromDictionary(ModbusCommands.AdcOverUnderload);
+                _legalForTradeOperation = _connection.GetDataFromDictionary(ModbusCommands.LegalForTradeOperation);
+                _statusInput1 = _connection.GetDataFromDictionary(ModbusCommands.StatusInput1);
+                _generalScaleError = _connection.GetDataFromDictionary(ModbusCommands.GeneralScaleError);
+                
+                _coarseFlow = _connection.GetDataFromDictionary(ModbusCommands.CoarseFlow);
+                _fineFlow = _connection.GetDataFromDictionary(ModbusCommands.FineFlow);
+                _ready = _connection.GetDataFromDictionary(ModbusCommands.Ready);
+                _reDosing = _connection.GetDataFromDictionary(ModbusCommands.ReDosing);
+
+                _emptying = _connection.GetDataFromDictionary(ModbusCommands.Emptying);
+                _flowError = _connection.GetDataFromDictionary(ModbusCommands.FlowError);
+                _alarm = _connection.GetDataFromDictionary(ModbusCommands.Alarm);
+                _toleranceErrorPlus = _connection.GetDataFromDictionary(ModbusCommands.ToleranceErrorPlus);
+
+                _toleranceErrorMinus = _connection.GetDataFromDictionary(ModbusCommands.ToleranceErrorMinus);
+                _currentDosingTime = _connection.GetDataFromDictionary(ModbusCommands.Dosing_time);
+                _currentCoarseFlowTime = _connection.GetDataFromDictionary(ModbusCommands.Coarse_flow_time);
+                _currentFineFlowTime = _connection.GetDataFromDictionary(ModbusCommands.CurrentFineFlowTime);
+
+                _parameterSetProduct = _connection.GetDataFromDictionary(ModbusCommands.ParameterSetProduct);
+                //_downwardsDosing = _connection.GetDataFromDictionary(ModbusCommands.DownwardsDosing);
+                _totalWeight = _connection.GetDataFromDictionary(ModbusCommands.TotalWeight);
+
+                //_targetFillingWeight = Convert.ToInt32(e.DataDictionary[ModbusCommands.TargetFillingWeight);
+                _coarseFlowCutOffPointSet = _connection.GetDataFromDictionary(ModbusCommands.Coarse_flow_cut_off_point);
+                _fineFlowCutOffPointSet = _connection.GetDataFromDictionary(ModbusCommands.Fine_flow_cut_off_point);
+                _startWithFineFlow = _connection.GetDataFromDictionary(ModbusCommands.Run_start_dosing);  // Command 'Run_start_dosing' right
+                
+                _weightMemoryDay = _connection.GetDataFromDictionary(ModbusCommands.WeightMemDayStandard);
+                _weightMemoryMonth = _connection.GetDataFromDictionary(ModbusCommands.WeightMemMonthStandard);
+                _weightMemoryYear = _connection.GetDataFromDictionary(ModbusCommands.WeightMemYearStandard);
+                _weightMemorySeqNumber = _connection.GetDataFromDictionary(ModbusCommands.WeightMemSeqNumberStandard);
+                _weightMemoryGross = _connection.GetDataFromDictionary(ModbusCommands.WeightMemGrossStandard);
+                _weightMemoryNet = _connection.GetDataFromDictionary(ModbusCommands.WeightMemNetStandard);
             }
         }
         #endregion
@@ -432,7 +430,7 @@ namespace HBM.Weighing.API.Data
             get { return _residualFlowTime; }
             set
             {
-                _connection.WriteArray(_commands.Residual_flow_time.Register, value);
+                _connection.WriteArray(ModbusCommands.Residual_flow_time.Register, value);
                 this._residualFlowTime = value;
             }
         }
@@ -441,7 +439,7 @@ namespace HBM.Weighing.API.Data
             get { return _targetFillingWeight; }
             set
             {
-                _connection.WriteArray(_commands.Reference_value_dosing.Register, value);
+                _connection.WriteArray(ModbusCommands.Reference_value_dosing.Register, value);
                 this._targetFillingWeight = value;
             }
         }
@@ -450,7 +448,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseFlowCutOffPointSet; }
             set
             {
-                _connection.WriteArray(_commands.Coarse_flow_cut_off_point.Register, value);
+                _connection.WriteArray(ModbusCommands.Coarse_flow_cut_off_point.Register, value);
                 this._coarseFlowCutOffPointSet = value;
             }
         }
@@ -459,7 +457,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineFlowCutOffPointSet; }
             set
             {
-                _connection.WriteArray(_commands.Fine_flow_cut_off_point.Register, value);
+                _connection.WriteArray(ModbusCommands.Fine_flow_cut_off_point.Register, value);
                 this._fineFlowCutOffPointSet = value;
             }
         }
@@ -468,7 +466,7 @@ namespace HBM.Weighing.API.Data
             get { return _minimumFineFlow; }
             set
             {
-                _connection.WriteArray(_commands.Minimum_fine_flow.Register, value);
+                _connection.WriteArray(ModbusCommands.Minimum_fine_flow.Register, value);
                 this._minimumFineFlow = value;
             }
         }
@@ -477,7 +475,7 @@ namespace HBM.Weighing.API.Data
             get { return _optimizationOfCutOffPoints; }
             set
             {
-                _connection.Write(_commands.Optimization.Register, value);
+                _connection.Write(ModbusCommands.Optimization.Register, value);
                 this._optimizationOfCutOffPoints = value;
             }
         }
@@ -486,7 +484,7 @@ namespace HBM.Weighing.API.Data
             get { return _maximumDosingTime; }
             set
             {
-                _connection.WriteArray(_commands.Maximal_dosing_time.Register, value);
+                _connection.WriteArray(ModbusCommands.Maximal_dosing_time.Register, value);
                 this._maximumDosingTime = value;
             }
         }
@@ -495,7 +493,7 @@ namespace HBM.Weighing.API.Data
             get { return _startWithFineFlow; }
             set
             {
-                _connection.WriteArray(_commands.Run_start_dosing.Register, value);
+                _connection.WriteArray(ModbusCommands.Run_start_dosing.Register, value);
                 this._startWithFineFlow = value;
             }
         }
@@ -504,7 +502,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseLockoutTime; }
             set
             {
-                _connection.WriteArray(_commands.Lockout_time_coarse_flow.Register, value);
+                _connection.WriteArray(ModbusCommands.Lockout_time_coarse_flow.Register, value);
                 this._coarseLockoutTime = value;
             }
         }
@@ -513,7 +511,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineLockoutTime; }
             set
             {
-                _connection.WriteArray(_commands.Lockout_time_fine_flow.Register, value);
+                _connection.WriteArray(ModbusCommands.Lockout_time_fine_flow.Register, value);
                 this._fineLockoutTime = value;
             }
         }
@@ -522,7 +520,7 @@ namespace HBM.Weighing.API.Data
             get { return _tareMode; }
             set
             {
-                _connection.Write(_commands.Tare_mode.Register, value);
+                _connection.Write(ModbusCommands.Tare_mode.Register, value);
                 this._tareMode = value;
             }
         }
@@ -531,7 +529,7 @@ namespace HBM.Weighing.API.Data
             get { return _upperToleranceLimit; }
             set
             {
-                _connection.WriteArray(_commands.Upper_tolerance_limit.Register, value);
+                _connection.WriteArray(ModbusCommands.Upper_tolerance_limit.Register, value);
                 this._upperToleranceLimit = value;
             }
         }
@@ -540,7 +538,7 @@ namespace HBM.Weighing.API.Data
             get { return _lowerToleranceLimit; }
             set
             {
-                _connection.WriteArray(_commands.Lower_tolerance_limit.Register, value);
+                _connection.WriteArray(ModbusCommands.Lower_tolerance_limit.Register, value);
                 this._lowerToleranceLimit = value;
             }
         }
@@ -549,7 +547,7 @@ namespace HBM.Weighing.API.Data
             get { return _minimumStartWeight; }
             set
             {
-                _connection.WriteArray(_commands.Minimum_start_weight.Register, value);
+                _connection.WriteArray(ModbusCommands.Minimum_start_weight.Register, value);
                 this._minimumStartWeight = value;
             }
         }
@@ -558,7 +556,7 @@ namespace HBM.Weighing.API.Data
             get { return _emptyWeight; }
             set
             {
-                _connection.WriteArray(_commands.Empty_weight.Register, value);
+                _connection.WriteArray(ModbusCommands.Empty_weight.Register, value);
                 this._emptyWeight = value;
             }
         }
@@ -567,7 +565,7 @@ namespace HBM.Weighing.API.Data
             get { return _tareDelay; }
             set
             {
-                _connection.WriteArray(_commands.Tare_delay.Register, value);
+                _connection.WriteArray(ModbusCommands.Tare_delay.Register, value);
                 this._tareDelay = value;
             }
         }
@@ -576,7 +574,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseFlowMonitoringTime; }
             set
             {
-                _connection.WriteArray(_commands.Coarse_flow_monitoring_time.Register, value);
+                _connection.WriteArray(ModbusCommands.Coarse_flow_monitoring_time.Register, value);
                 this._coarseFlowMonitoringTime = value;
             }
         }
@@ -585,7 +583,7 @@ namespace HBM.Weighing.API.Data
             get { return _coarseFlowMonitoring; }
             set
             {
-                _connection.WriteArray(_commands.Coarse_flow_monitoring.Register, value);
+                _connection.WriteArray(ModbusCommands.Coarse_flow_monitoring.Register, value);
                 this._coarseFlowMonitoring = value;
             }
         }
@@ -594,7 +592,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineFlowMonitoring; }
             set
             {
-                _connection.WriteArray(_commands.Fine_flow_monitoring.Register, value);
+                _connection.WriteArray(ModbusCommands.Fine_flow_monitoring.Register, value);
                 this._fineFlowMonitoring = value;
             }
         }
@@ -603,7 +601,7 @@ namespace HBM.Weighing.API.Data
             get { return _fineFlowMonitoringTime; }
             set
             {
-                _connection.WriteArray(_commands.Fine_flow_monitoring_time.Register, value);
+                _connection.WriteArray(ModbusCommands.Fine_flow_monitoring_time.Register, value);
                 this._fineFlowMonitoringTime = value;
             }
         }
@@ -630,7 +628,7 @@ namespace HBM.Weighing.API.Data
             get { return _systematicDifference; }
             set
             {
-                _connection.WriteArray(_commands.Systematic_difference.Register, value);
+                _connection.WriteArray(ModbusCommands.Systematic_difference.Register, value);
                 this._systematicDifference = value;
             }
         }
@@ -647,7 +645,7 @@ namespace HBM.Weighing.API.Data
             get { return _valveControl; }
             set
             {
-                _connection.Write(_commands.Valve_control.Register, value);
+                _connection.Write(ModbusCommands.Valve_control.Register, value);
                 this._valveControl = value;
             }
         }
@@ -657,7 +655,7 @@ namespace HBM.Weighing.API.Data
             get { return _emptyingMode; }
             set
             {
-                _connection.Write(_commands.Emptying_mode.Register, value);
+                _connection.Write(ModbusCommands.Emptying_mode.Register, value);
                 this._emptyingMode = value;
             }
         }

--- a/HBM.Weighing.API/Data/DataStandardJet.cs
+++ b/HBM.Weighing.API/Data/DataStandardJet.cs
@@ -123,14 +123,14 @@ namespace HBM.Weighing.API.Data
         private int _zeroLoad;
         private int _nominalLoad;
 
-        private INetConnection _connection;
+        private JetBusConnection _connection;
         #endregion
 
         #region constructor
 
         public DataStandardJet(INetConnection Connection)
         {
-            _connection = Connection;
+            _connection = (JetBusConnection) Connection;
 
             _connection.UpdateDataClasses += UpdateStandardData;
 
@@ -206,46 +206,46 @@ namespace HBM.Weighing.API.Data
 
         #region Update methods for standard mode
 
-        public void UpdateStandardData(object sender, DataEventArgs e)
+        public void UpdateStandardData(object sender, EventArgs e)
         {
-            _input1 = e.DataDictionary[JetBusCommands.Status_digital_input_1.PathIndex];
-            _input2 = e.DataDictionary[JetBusCommands.Status_digital_input_2.PathIndex];
-            _input3 = e.DataDictionary[JetBusCommands.Status_digital_input_3.PathIndex];
-            _input4 = e.DataDictionary[JetBusCommands.Status_digital_input_4.PathIndex];
+            _input1 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_input_1);
+            _input2 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_input_2);
+            _input3 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_input_3);
+            _input4 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_input_4);
 
-            _output1 = e.DataDictionary[JetBusCommands.Status_digital_output_1.PathIndex];
-            _output2 = e.DataDictionary[JetBusCommands.Status_digital_output_2.PathIndex];
-            _output3 = e.DataDictionary[JetBusCommands.Status_digital_output_3.PathIndex];
-            _output4 = e.DataDictionary[JetBusCommands.Status_digital_output_4.PathIndex];
+            _output1 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_output_1);
+            _output2 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_output_2);
+            _output3 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_output_3);
+            _output4 = _connection.GetDataFromDictionary(JetBusCommands.Status_digital_output_4);
 
-            _limitStatus1 = (e.DataDictionary[JetBusCommands.Limit_value.PathIndex] & 0x1);
-            _limitStatus2 = (e.DataDictionary[JetBusCommands.Limit_value.PathIndex] & 0x2) >> 1;
-            _limitStatus3 = (e.DataDictionary[JetBusCommands.Limit_value.PathIndex] & 0x4) >> 2;
-            _limitStatus4 = (e.DataDictionary[JetBusCommands.Limit_value.PathIndex] & 0x8) >> 3;
+            _limitStatus1 = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_status1);
+            _limitStatus2 = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_status2);
+            _limitStatus3 = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_status3);
+            _limitStatus4 = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_status4);
 
-            _weight_storage = Convert.ToInt16(e.DataDictionary[(JetBusCommands.Storage_weight_mode).PathIndex]);
+            _weight_storage = _connection.GetDataFromDictionary(JetBusCommands.Storage_weight_mode);
 
-            if (e.DataDictionary[JetBusCommands.Application_mode.PathIndex] == 0 || e.DataDictionary[JetBusCommands.Application_mode.PathIndex] == 1)  // If application mode is in standard mode
+            if (_connection.GetDataFromDictionary(JetBusCommands.Application_mode) == 0 || _connection.GetDataFromDictionary(JetBusCommands.Application_mode) == 1)  // If application mode is in standard mode
             {
-                _limitSwitch1Source = e.DataDictionary[JetBusCommands.Limit_value_monitoring_liv11.PathIndex];
-                _limitSwitch1Mode = e.DataDictionary[JetBusCommands.Signal_source_liv12.PathIndex];
-                _limitSwitch1ActivationLevelLowerBandLimit = e.DataDictionary[JetBusCommands.Switch_on_level_liv13.PathIndex];
-                _limitSwitch1HysteresisBandHeight = e.DataDictionary[JetBusCommands.Switch_off_level_liv14.PathIndex];
+                _limitSwitch1Source = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_monitoring_liv11);
+                _limitSwitch1Mode   = _connection.GetDataFromDictionary(JetBusCommands.Signal_source_liv12);
+                _limitSwitch1ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(JetBusCommands.Switch_on_level_liv13);
+                _limitSwitch1HysteresisBandHeight          = _connection.GetDataFromDictionary(JetBusCommands.Switch_off_level_liv14);
 
-                _limitSwitch2Source = e.DataDictionary[JetBusCommands.Limit_value_monitoring_liv21.PathIndex];
-                _limitSwitch2Mode = e.DataDictionary[JetBusCommands.Signal_source_liv22.PathIndex];
-                _limitSwitch2ActivationLevelLowerBandLimit = e.DataDictionary[JetBusCommands.Switch_on_level_liv23.PathIndex];
-                _limitSwitch2HysteresisBandHeight = e.DataDictionary[JetBusCommands.Switch_off_level_liv24.PathIndex];
+                _limitSwitch2Source = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_monitoring_liv21);
+                _limitSwitch2Mode   = _connection.GetDataFromDictionary(JetBusCommands.Signal_source_liv22);
+                _limitSwitch2ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(JetBusCommands.Switch_on_level_liv23);
+                _limitSwitch2HysteresisBandHeight          = _connection.GetDataFromDictionary(JetBusCommands.Switch_off_level_liv24);
 
-                _limitSwitch3Source = e.DataDictionary[JetBusCommands.Limit_value_monitoring_liv31.PathIndex];
-                _limitSwitch3Mode = e.DataDictionary[JetBusCommands.Signal_source_liv32.PathIndex];
-                _limitSwitch3ActivationLevelLowerBandLimit = e.DataDictionary[JetBusCommands.Switch_on_level_liv33.PathIndex];
-                _limitSwitch3HysteresisBandHeight = e.DataDictionary[JetBusCommands.Switch_off_level_liv34.PathIndex];
+                _limitSwitch3Source = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_monitoring_liv31);
+                _limitSwitch3Mode   = _connection.GetDataFromDictionary(JetBusCommands.Signal_source_liv32);
+                _limitSwitch3ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(JetBusCommands.Switch_on_level_liv33);
+                _limitSwitch3HysteresisBandHeight          = _connection.GetDataFromDictionary(JetBusCommands.Switch_off_level_liv34);
 
-                _limitSwitch4Source = e.DataDictionary[JetBusCommands.Limit_value_monitoring_liv41.PathIndex];
-                _limitSwitch4Mode = e.DataDictionary[JetBusCommands.Signal_source_liv42.PathIndex];
-                _limitSwitch4ActivationLevelLowerBandLimit = e.DataDictionary[JetBusCommands.Switch_on_level_liv43.PathIndex];
-                _limitSwitch4HysteresisBandHeight = e.DataDictionary[JetBusCommands.Switch_off_level_liv44.PathIndex];
+                _limitSwitch4Source = _connection.GetDataFromDictionary(JetBusCommands.Limit_value_monitoring_liv41);
+                _limitSwitch4Mode   = _connection.GetDataFromDictionary(JetBusCommands.Signal_source_liv42);
+                _limitSwitch4ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(JetBusCommands.Switch_on_level_liv43);
+                _limitSwitch4HysteresisBandHeight          = _connection.GetDataFromDictionary(JetBusCommands.Switch_off_level_liv44);
             }
         }
         #endregion

--- a/HBM.Weighing.API/Data/DataStandardModbus.cs
+++ b/HBM.Weighing.API/Data/DataStandardModbus.cs
@@ -97,15 +97,12 @@ namespace HBM.Weighing.API.Data
         private int _limitSwitch4HysteresisBandHeight;
                
         private ModbusTcpConnection _connection;
-        private ModbusCommands _commands;
         #endregion
 
         #region constructor
 
         public DataStandardModbus(INetConnection Connection)
         {
-            _commands = new ModbusCommands();
-
             _connection = (ModbusTcpConnection)Connection;
 
             _connection.UpdateDataClasses += UpdateStandardData;
@@ -159,51 +156,51 @@ namespace HBM.Weighing.API.Data
 
         #region Update methods for standard mode
 
-        public void UpdateStandardData(object sender, DataEventArgs e)
+        public void UpdateStandardData(object sender, EventArgs e)
         {
-            _input1 = _connection.GetDataFromDictionary(_commands.Status_digital_input_1);
-            _input2 = _connection.GetDataFromDictionary(_commands.Status_digital_input_2);
-            _input3 = _connection.GetDataFromDictionary(_commands.Status_digital_input_3);
-            _input4 = _connection.GetDataFromDictionary(_commands.Status_digital_input_4);
+            _input1 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_input_1);
+            _input2 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_input_2);
+            _input3 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_input_3);
+            _input4 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_input_4);
 
-            _output1 = _connection.GetDataFromDictionary(_commands.Status_digital_output_1);
-            _output2 = _connection.GetDataFromDictionary(_commands.Status_digital_output_2);
-            _output3 = _connection.GetDataFromDictionary(_commands.Status_digital_output_3);
-            _output4 = _connection.GetDataFromDictionary(_commands.Status_digital_output_4);
+            _output1 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_output_1);
+            _output2 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_output_2);
+            _output3 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_output_3);
+            _output4 = _connection.GetDataFromDictionary(ModbusCommands.Status_digital_output_4);
 
-            _limitStatus1 = _connection.GetDataFromDictionary(_commands.Limit_value);
-            _limitStatus2 = _connection.GetDataFromDictionary(_commands.Limit_value);
-            _limitStatus3 = _connection.GetDataFromDictionary(_commands.Limit_value);
-            _limitStatus4 = _connection.GetDataFromDictionary(_commands.Limit_value);
+            _limitStatus1 = _connection.GetDataFromDictionary(ModbusCommands.Limit_value);
+            _limitStatus2 = _connection.GetDataFromDictionary(ModbusCommands.Limit_value);
+            _limitStatus3 = _connection.GetDataFromDictionary(ModbusCommands.Limit_value);
+            _limitStatus4 = _connection.GetDataFromDictionary(ModbusCommands.Limit_value);
 
-            _weightMemoryDay = Convert.ToInt16(_connection.GetDataFromDictionary(_commands.WeightMemDayStandard));
-            _weightMemoryMonth = Convert.ToInt16(_connection.GetDataFromDictionary(_commands.WeightMemMonthStandard));
-            _weightMemoryYear = Convert.ToInt16(_connection.GetDataFromDictionary(_commands.WeightMemYearStandard));
-            _weightMemorySeqNumber = Convert.ToInt16(_connection.GetDataFromDictionary(_commands.WeightMemSeqNumberStandard));
-            _weightMemoryGross = Convert.ToInt16(_connection.GetDataFromDictionary(_commands.WeightMemGrossStandard));
-            _weightMemoryNet = Convert.ToInt16(_connection.GetDataFromDictionary(_commands.WeightMemNetStandard));
+            _weightMemoryDay = Convert.ToInt16(_connection.GetDataFromDictionary(ModbusCommands.WeightMemDayStandard));
+            _weightMemoryMonth = Convert.ToInt16(_connection.GetDataFromDictionary(ModbusCommands.WeightMemMonthStandard));
+            _weightMemoryYear = Convert.ToInt16(_connection.GetDataFromDictionary(ModbusCommands.WeightMemYearStandard));
+            _weightMemorySeqNumber = Convert.ToInt16(_connection.GetDataFromDictionary(ModbusCommands.WeightMemSeqNumberStandard));
+            _weightMemoryGross = Convert.ToInt16(_connection.GetDataFromDictionary(ModbusCommands.WeightMemGrossStandard));
+            _weightMemoryNet = Convert.ToInt16(_connection.GetDataFromDictionary(ModbusCommands.WeightMemNetStandard));
 
-            if (_connection.GetDataFromDictionary(_commands.Application_mode) == 0 || _connection.GetDataFromDictionary(_commands.Application_mode) == 1)  // If application mode is in standard mode
+            if (_connection.GetDataFromDictionary(ModbusCommands.Application_mode) == 0 || _connection.GetDataFromDictionary(ModbusCommands.Application_mode) == 1)  // If application mode is in standard mode
             {
-                _limitSwitch1Input = _connection.GetDataFromDictionary(_commands.LimitValue1Mode);
-                _limitSwitch1Mode = _connection.GetDataFromDictionary(_commands.LimitValue1Input);
-                _limitSwitch1ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(_commands.LimitValue1ActivationLevelLowerBandLimit);
-                _limitSwitch1HysteresisBandHeight = _connection.GetDataFromDictionary(_commands.LimitValue1HysteresisBandHeight);
+                _limitSwitch1Input = _connection.GetDataFromDictionary(ModbusCommands.LimitValue1Mode);
+                _limitSwitch1Mode = _connection.GetDataFromDictionary(ModbusCommands.LimitValue1Input);
+                _limitSwitch1ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(ModbusCommands.LimitValue1ActivationLevelLowerBandLimit);
+                _limitSwitch1HysteresisBandHeight = _connection.GetDataFromDictionary(ModbusCommands.LimitValue1HysteresisBandHeight);
 
-                _limitSwitch2Mode = _connection.GetDataFromDictionary(_commands.LimitValue2Source);
-                _limitSwitch2Source = _connection.GetDataFromDictionary(_commands.LimitValue2Mode);
-                _limitSwitch2ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(_commands.LimitValue2ActivationLevelLowerBandLimit);
-                _limitSwitch2HysteresisBandHeight = _connection.GetDataFromDictionary(_commands.LimitValue2HysteresisBandHeight);
+                _limitSwitch2Mode = _connection.GetDataFromDictionary(ModbusCommands.LimitValue2Source);
+                _limitSwitch2Source = _connection.GetDataFromDictionary(ModbusCommands.LimitValue2Mode);
+                _limitSwitch2ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(ModbusCommands.LimitValue2ActivationLevelLowerBandLimit);
+                _limitSwitch2HysteresisBandHeight = _connection.GetDataFromDictionary(ModbusCommands.LimitValue2HysteresisBandHeight);
 
-                _limitSwitch3Mode = _connection.GetDataFromDictionary(_commands.LimitValue3Source);
-                _limitSwitch3Source = _connection.GetDataFromDictionary(_commands.LimitValue3Mode);
-                _limitSwitch3ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(_commands.LimitValue3ActivationLevelLowerBandLimit);
-                _limitSwitch3HysteresisBandHeight = _connection.GetDataFromDictionary(_commands.LimitValue3HysteresisBandHeight);
+                _limitSwitch3Mode = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3Source);
+                _limitSwitch3Source = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3Mode);
+                _limitSwitch3ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3ActivationLevelLowerBandLimit);
+                _limitSwitch3HysteresisBandHeight = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3HysteresisBandHeight);
 
-                _limitSwitch4Mode = _connection.GetDataFromDictionary(_commands.LimitValue3Source);
-                _limitSwitch4Source = _connection.GetDataFromDictionary(_commands.LimitValue3Mode);
-                _limitSwitch4ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(_commands.LimitValue3ActivationLevelLowerBandLimit);
-                _limitSwitch4HysteresisBandHeight = _connection.GetDataFromDictionary(_commands.LimitValue3HysteresisBandHeight);
+                _limitSwitch4Mode = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3Source);
+                _limitSwitch4Source = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3Mode);
+                _limitSwitch4ActivationLevelLowerBandLimit = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3ActivationLevelLowerBandLimit);
+                _limitSwitch4HysteresisBandHeight = _connection.GetDataFromDictionary(ModbusCommands.LimitValue3HysteresisBandHeight);
             }
         }
         #endregion
@@ -215,7 +212,7 @@ namespace HBM.Weighing.API.Data
             get { return _input1; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_1.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_input_1.Register, value);
                 _input1 = value;
             }
         }
@@ -224,7 +221,7 @@ namespace HBM.Weighing.API.Data
             get { return _input2; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_2.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_input_2.Register, value);
                 _input2 = value;
             }
         }
@@ -233,7 +230,7 @@ namespace HBM.Weighing.API.Data
             get { return _input3; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_3.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_input_3.Register, value);
                 _input3 = value;
             }
         }
@@ -242,7 +239,7 @@ namespace HBM.Weighing.API.Data
             get { return _input4; }
             set
             {
-                _connection.Write(_commands.Status_digital_input_4.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_input_4.Register, value);
                 _input4 = value;
             }
         }
@@ -251,7 +248,7 @@ namespace HBM.Weighing.API.Data
             get { return _output1; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_1.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_output_1.Register, value);
                 _output1 = value;
             }
         }
@@ -260,7 +257,7 @@ namespace HBM.Weighing.API.Data
             get { return _output2; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_2.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_output_2.Register, value);
                 _output2 = value;
             }
         }
@@ -269,7 +266,7 @@ namespace HBM.Weighing.API.Data
             get { return _output3; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_3.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_output_3.Register, value);
                 _output3 = value;
             }
         }
@@ -278,7 +275,7 @@ namespace HBM.Weighing.API.Data
             get { return _output4; }
             set
             {
-                _connection.Write(_commands.Status_digital_output_4.Register, value);
+                _connection.Write(ModbusCommands.Status_digital_output_4.Register, value);
                 _output4 = value;
             }
         }
@@ -331,7 +328,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1Input; }
             set
             {
-                _connection.Write(_commands.ManualTareValue.Register, value);
+                _connection.Write(ModbusCommands.ManualTareValue.Register, value);
                 _limitSwitch1Input = value;
             }
         }
@@ -340,7 +337,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1Mode; }
             set
             {
-                _connection.Write(_commands.LimitValue1Input.Register, value);
+                _connection.Write(ModbusCommands.LimitValue1Input.Register, value);
                 _limitSwitch1Mode = value;
             }
         }
@@ -349,7 +346,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.Write(_commands.LimitValue1Mode.Register, value);
+                _connection.Write(ModbusCommands.LimitValue1Mode.Register, value);
                 _limitSwitch1ActivationLevelLowerBandLimit = value;
             }
         }
@@ -358,7 +355,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.LimitValue1HysteresisBandHeight.Register, value);
+                _connection.Write(ModbusCommands.LimitValue1HysteresisBandHeight.Register, value);
                 _limitSwitch1HysteresisBandHeight = value;
             }
         }
@@ -367,7 +364,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1ActivationLevelLowerBandLimit; }
             set
             {
-                this._connection.WriteArray(_commands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
+                this._connection.WriteArray(ModbusCommands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch1ActivationLevelLowerBandLimit = value;
             }
         }
@@ -376,7 +373,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch1HysteresisBandHeight; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue1HysteresisBandHeight.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue1HysteresisBandHeight.Register, value);
                 _limitSwitch1HysteresisBandHeight = value;
             }
         }
@@ -386,7 +383,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2Source; }
             set
             {
-                _connection.Write(_commands.LimitValue2Source.Register, value);
+                _connection.Write(ModbusCommands.LimitValue2Source.Register, value);
                 _limitSwitch2Source = value;
             }
         }
@@ -395,7 +392,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2Mode; }
             set
             {
-                _connection.Write(_commands.LimitValue2Mode.Register, value);
+                _connection.Write(ModbusCommands.LimitValue2Mode.Register, value);
                 _limitSwitch2Mode = value;
             }
         }
@@ -404,7 +401,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.Write(_commands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
+                _connection.Write(ModbusCommands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch2ActivationLevelLowerBandLimit = value;
             }
         }
@@ -413,7 +410,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.LimitValue2HysteresisBandHeight.Register, value);
+                _connection.Write(ModbusCommands.LimitValue2HysteresisBandHeight.Register, value);
                 _limitSwitch2HysteresisBandHeight = value;
             }
         }
@@ -422,7 +419,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2ActivationLevelLowerBandLimit; }
             set
             {
-                this._connection.Write(_commands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
+                this._connection.Write(ModbusCommands.LimitValue2ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch2ActivationLevelLowerBandLimit = value;
             }
         }
@@ -431,7 +428,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch2HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.LimitValue2HysteresisBandHeight.Register, value);
+                _connection.Write(ModbusCommands.LimitValue2HysteresisBandHeight.Register, value);
                 _limitSwitch2HysteresisBandHeight = value;
             }
         }
@@ -440,7 +437,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3Source; }
             set
             {
-                _connection.Write(_commands.LimitValue3Source.Register, value);
+                _connection.Write(ModbusCommands.LimitValue3Source.Register, value);
                 _limitSwitch3Source = value;
             }
         }
@@ -449,7 +446,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3Mode; }
             set
             {
-                _connection.Write(_commands.LimitValue3Mode.Register, value);
+                _connection.Write(ModbusCommands.LimitValue3Mode.Register, value);
                 _limitSwitch3Mode = value;
             }
         }
@@ -458,7 +455,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch3ActivationLevelLowerBandLimit = value;
             }
         }
@@ -467,7 +464,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3HysteresisBandHeight; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue3HysteresisBandHeight.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue3HysteresisBandHeight.Register, value);
                 _limitSwitch3HysteresisBandHeight = value;
             }
         }
@@ -476,7 +473,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.Write(_commands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
+                _connection.Write(ModbusCommands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch3ActivationLevelLowerBandLimit = value;
             }
         }
@@ -485,7 +482,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch3HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.LimitValue3HysteresisBandHeight.Register, value);
+                _connection.Write(ModbusCommands.LimitValue3HysteresisBandHeight.Register, value);
                 _limitSwitch3HysteresisBandHeight = value;
             }
         }
@@ -494,7 +491,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4Source; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue4Source.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue4Source.Register, value);
                 _limitSwitch4Source = value;
             }
         }
@@ -503,7 +500,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4Mode; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue4Mode.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue4Mode.Register, value);
                 _limitSwitch4Mode = value;
             }
         }
@@ -512,7 +509,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue4ActivationLevelLowerBandLimit.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue4ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch4ActivationLevelLowerBandLimit = value;
             }
         }
@@ -521,7 +518,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4HysteresisBandHeight; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue4HysteresisBandHeight.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue4HysteresisBandHeight.Register, value);
                 _limitSwitch4HysteresisBandHeight = value;
             }
         }
@@ -530,7 +527,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4ActivationLevelLowerBandLimit; }
             set
             {
-                _connection.WriteArray(_commands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
+                _connection.WriteArray(ModbusCommands.LimitValue3ActivationLevelLowerBandLimit.Register, value);
                 _limitSwitch4ActivationLevelLowerBandLimit = value;
             }
         }
@@ -539,7 +536,7 @@ namespace HBM.Weighing.API.Data
             get { return _limitSwitch4HysteresisBandHeight; }
             set
             {
-                _connection.Write(_commands.LimitValue4HysteresisBandHeight.Register, value);
+                _connection.Write(ModbusCommands.LimitValue4HysteresisBandHeight.Register, value);
                 _limitSwitch4HysteresisBandHeight = value;
             }
         }

--- a/HBM.Weighing.API/Data/IDataFiller.cs
+++ b/HBM.Weighing.API/Data/IDataFiller.cs
@@ -130,7 +130,7 @@ namespace HBM.Weighing.API
 
         #region Update methods for the data of standard mode
 
-        void UpdateFillerData(object sender, DataEventArgs e);
+        void UpdateFillerData(object sender, EventArgs e);
 
         #endregion
     }

--- a/HBM.Weighing.API/Data/IDataFillerExtended.cs
+++ b/HBM.Weighing.API/Data/IDataFillerExtended.cs
@@ -125,7 +125,7 @@ namespace HBM.Weighing.API
 
         #region Update methods for the data of filler extended mode
         
-        void UpdateFillerExtendedData(object sender, DataEventArgs e);
+        void UpdateFillerExtendedData(object sender, EventArgs e);
 
         #endregion
     }

--- a/HBM.Weighing.API/Data/IDataStandard.cs
+++ b/HBM.Weighing.API/Data/IDataStandard.cs
@@ -102,9 +102,8 @@ namespace HBM.Weighing.API
 
         #endregion
 
-
         #region Update methods for the data of standard mode
-        void UpdateStandardData(object sender, DataEventArgs e);
+        void UpdateStandardData(object sender, EventArgs e);
         #endregion
     }
 }

--- a/HBM.Weighing.API/Data/IProcessData.cs
+++ b/HBM.Weighing.API/Data/IProcessData.cs
@@ -28,6 +28,8 @@
 //
 // </copyright>
 
+using System;
+
 namespace HBM.Weighing.API
 {
     /// <summary>
@@ -86,7 +88,7 @@ namespace HBM.Weighing.API
         #endregion
 
         #region Update method
-        void UpdateProcessData(object sender, DataEventArgs e);
+        void UpdateProcessData(object sender, EventArgs e);
         #endregion
     }
 }

--- a/HBM.Weighing.API/Data/ProcessDataJet.cs
+++ b/HBM.Weighing.API/Data/ProcessDataJet.cs
@@ -38,12 +38,13 @@ namespace HBM.Weighing.API.Data
     /// </summary>
     public class ProcessDataJet : IProcessData
     {
-        private INetConnection _connection;
+        private JetBusConnection _connection;
 
         #region Constructor
         public ProcessDataJet(INetConnection Connection)
         {
-            _connection = Connection;
+            _connection = (JetBusConnection) Connection;
+
             _connection.UpdateDataClasses += UpdateProcessData;
 
             NetValue = 0;
@@ -73,30 +74,30 @@ namespace HBM.Weighing.API.Data
 
 
         #region Update method
-        public void UpdateProcessData(object sender, DataEventArgs e)
+        public void UpdateProcessData(object sender, EventArgs e)
         {
-            ApplicationMode = (ApplicationMode)e.DataDictionary[JetBusCommands.Application_mode.PathIndex];
-            NetValue = Convert.ToInt32(e.DataDictionary[JetBusCommands.Net_value.PathIndex]);
-            GrossValue = Convert.ToInt32(e.DataDictionary[JetBusCommands.Gross_value.PathIndex]);
+            ApplicationMode = (ApplicationMode)_connection.GetDataFromDictionary(JetBusCommands.Application_mode);
+            NetValue = Convert.ToInt32(_connection.GetDataFromDictionary(JetBusCommands.Net_value));
+            GrossValue = Convert.ToInt32(_connection.GetDataFromDictionary(JetBusCommands.Gross_value));
             TareValue = NetValue - GrossValue;
-            //GeneralWeightError = GetDataFromDict(JetBusCommands.WS_GeneralWeightError);
-            GeneralWeightError = Convert.ToBoolean(Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x1);
-            ScaleAlarm = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x2) >> 1);
-            LimitStatus = (Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0xC) >> 2;
+
+            GeneralWeightError = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_GeneralWeightError));
+            ScaleAlarm = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_ScaleAlarm));
+            LimitStatus = Convert.ToInt32(_connection.GetDataFromDictionary(JetBusCommands.WS_LimitStatus));
             WeightWithinLimits = (LimitStatus == 0);
             Underload = (LimitStatus == 1);
             Overload = (LimitStatus == 2);
             HigherSafeLoadLimit = (LimitStatus == 3);
-            WeightMoving = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x10) >> 4);
-            ScaleSealIsOpen = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x20) >> 5);
-            ManualTare = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x40) >> 6);
-            TareMode = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x80) >> 7);
-            ScaleRange = (Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x300) >> 8;
-            ZeroRequired = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x400) >> 10);
-            CenterOfZero = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x800) >> 11);
-            InsideZero = Convert.ToBoolean((Convert.ToInt32(e.DataDictionary[JetBusCommands.Weighing_device_1_weight_status.PathIndex]) & 0x1000) >> 12);
-            Decimals = Convert.ToInt32(e.DataDictionary[JetBusCommands.Decimals.PathIndex]);
-            Unit = (Convert.ToInt32(e.DataDictionary[JetBusCommands.Unit_prefix_fixed_parameter.PathIndex]) & 0xFF0000) >> 16;                    
+            WeightMoving = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_WeightMoving));
+            ScaleSealIsOpen = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_ScaleSealIsOpen));
+            ManualTare = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_ManualTare));
+            TareMode = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_WeightType));  // TareMode != WeightType
+            ScaleRange = Convert.ToInt32(_connection.GetDataFromDictionary(JetBusCommands.WS_ScaleRange));
+            ZeroRequired = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_ZeroRequired));
+            CenterOfZero = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_CenterOfZero));
+            InsideZero = Convert.ToBoolean(_connection.GetDataFromDictionary(JetBusCommands.WS_InsideZero));
+            Decimals = Convert.ToInt32(_connection.GetDataFromDictionary(JetBusCommands.Decimals));
+            Unit = Convert.ToInt32(_connection.GetDataFromDictionary(JetBusCommands.WS_Unit));
         }
         #endregion
 

--- a/HBM.Weighing.API/Data/ProcessDataModbus.cs
+++ b/HBM.Weighing.API/Data/ProcessDataModbus.cs
@@ -39,14 +39,12 @@ namespace HBM.Weighing.API.Data
     public class ProcessDataModbus : IProcessData
     {
         private ModbusTcpConnection _connection;
-        private ModbusCommands _commands;
 
         #region Constructor
         public ProcessDataModbus(INetConnection Connection)
         {
-            _commands = new ModbusCommands();
-
             _connection = (ModbusTcpConnection) Connection;
+
             _connection.UpdateDataClasses += UpdateProcessData;
 
             NetValue = 0;
@@ -75,34 +73,34 @@ namespace HBM.Weighing.API.Data
         #endregion
 
         #region Update method
-        public void UpdateProcessData(object sender, DataEventArgs e)
+        public void UpdateProcessData(object sender, EventArgs e)
         {
-            NetValue = _connection.GetDataFromDictionary(_commands.Net);
-            GrossValue = _connection.GetDataFromDictionary(_commands.Gross);
+            NetValue = _connection.GetDataFromDictionary(ModbusCommands.Net);
+            GrossValue = _connection.GetDataFromDictionary(ModbusCommands.Gross);
             TareValue = NetValue - GrossValue;
-            GeneralWeightError = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.GeneralWeightError));
+            GeneralWeightError = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.GeneralWeightError));
 
-            ScaleAlarm = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.ScaleAlarmTriggered));
-            LimitStatus = (Convert.ToInt32(_connection.GetDataFromDictionary(_commands.Limit_status))); 
+            ScaleAlarm = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.ScaleAlarmTriggered));
+            LimitStatus = (Convert.ToInt32(_connection.GetDataFromDictionary(ModbusCommands.Limit_status))); 
             WeightWithinLimits = (LimitStatus == 0);
             Underload = (LimitStatus == 1);
             Overload = (LimitStatus == 2);
             HigherSafeLoadLimit = (LimitStatus == 3);
 
-            WeightMoving = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.WeightMoving));
-            ScaleSealIsOpen = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.ScaleSealIsOpen));
-            ManualTare = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.ManualTare));
-            TareMode = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.Tare_mode));
-            ScaleRange = Convert.ToInt32(_connection.GetDataFromDictionary(_commands.ScaleRange));
-            ZeroRequired = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.ZeroRequired));
-            CenterOfZero = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.WeightinCenterOfZero));
-            InsideZero = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.WeightinZeroRange));
+            WeightMoving = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.WeightMoving));
+            ScaleSealIsOpen = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.ScaleSealIsOpen));
+            ManualTare = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.ManualTare));
+            TareMode = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.Tare_mode));
+            ScaleRange = Convert.ToInt32(_connection.GetDataFromDictionary(ModbusCommands.ScaleRange));
+            ZeroRequired = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.ZeroRequired));
+            CenterOfZero = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.WeightinCenterOfZero));
+            InsideZero = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.WeightinZeroRange));
 
-            ApplicationMode = (ApplicationMode)_connection.GetDataFromDictionary(_commands.Application_mode);
-            Decimals = _connection.GetDataFromDictionary(_commands.Decimals);
-            Unit = _connection.GetDataFromDictionary(_commands.Unit);
-            Handshake = Convert.ToBoolean(_connection.GetDataFromDictionary(_commands.Handshake));
-            Status = _connection.GetDataFromDictionary(_commands.Status);
+            ApplicationMode = (ApplicationMode)_connection.GetDataFromDictionary(ModbusCommands.Application_mode);
+            Decimals = _connection.GetDataFromDictionary(ModbusCommands.Decimals);
+            Unit = _connection.GetDataFromDictionary(ModbusCommands.Unit);
+            Handshake = Convert.ToBoolean(_connection.GetDataFromDictionary(ModbusCommands.Handshake));
+            Status = _connection.GetDataFromDictionary(ModbusCommands.Status);
         }
         #endregion
 

--- a/HBM.Weighing.API/INetConnection.cs
+++ b/HBM.Weighing.API/INetConnection.cs
@@ -48,18 +48,14 @@ namespace HBM.Weighing.API
 
         event EventHandler<DataEventArgs> IncomingDataReceived;
 
-        event EventHandler<DataEventArgs> UpdateDataClasses;
+        event EventHandler<EventArgs> UpdateDataClasses;
 
         #endregion
 
         #region Attributes for data, commands, ip address, connection, connection type
 
         Dictionary<string,int>AllData { get; }
-        /*
-        Dictionary<ModbusCommand, int> ModbusData { get; }  // dictionary list containing pairs of paths-values via Modbus
 
-        Dictionary<JetBusCommand, int> JetBusData { get; }  // dictionary list containing pairs of paths-values via Jetbus
-        */
         string IpAddress    { get; set; }                   // ip address establishing a connection to the device
 
         bool IsConnected    { get; }                        // boolean stating the connection status

--- a/HBM.Weighing.API/WTX/Jet/JetBusCommands.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusCommands.cs
@@ -61,7 +61,21 @@ namespace HBM.Weighing.API.WTX.Jet
             Weighing_device_1_weight_status = new JetBusCommand(1, "6012/01", 0, 0);
 
             WS_GeneralWeightError = new JetBusCommand(1, "6012/01", 0, 1);
+            WS_ScaleAlarm = new JetBusCommand(1, "6012/01", 1, 1);
+            WS_LimitStatus = new JetBusCommand(1, "6012/01", 2, 2);
+            WS_WeightMoving = new JetBusCommand(1, "6012/01", 4, 1);
+            WS_ScaleSealIsOpen = new JetBusCommand(1, "6012/01", 5, 1);
+            WS_ManualTare = new JetBusCommand(1, "6012/01", 6, 1);
+            WS_WeightType = new JetBusCommand(1, "6012/01", 7, 1);
+            WS_ScaleRange = new JetBusCommand(1, "6012/01", 8, 2);
+            WS_ZeroRequired = new JetBusCommand(1, "6012/01", 10, 1);
+            WS_CenterOfZero = new JetBusCommand(1, "6012/01", 11, 1);
+            WS_InsideZero = new JetBusCommand(1, "6012/01", 12, 1);
+            WS_Reserved = new JetBusCommand(1, "6012/01", 13, 1);
+            WS_ImplementationSpecificWeightStatus1 = new JetBusCommand(1, "6012/01", 14, 1);
+            WS_ImplementationSpecificWeightStatus2 = new JetBusCommand(1, "6012/01", 14, 1);
 
+            WS_Unit = new JetBusCommand(1, "6014/01", 16, 8);
             Unit_prefix_fixed_parameter = new JetBusCommand(1, "6014/01", 0, 0);
             Application_mode = new JetBusCommand(1, "2010/07", 0, 0); // IMD = Input mode ( Application mode)
             Decimals = new JetBusCommand(1, "6013/01", 0, 0);
@@ -77,7 +91,11 @@ namespace HBM.Weighing.API.WTX.Jet
             Status_digital_output_3 = new JetBusCommand(1, "2020/20", 0, 0);   // OS3
             Status_digital_output_4 = new JetBusCommand(1, "2020/21", 0, 0);   // OS4
 
-            Limit_value = new JetBusCommand(1, "2020/25", 0, 0);   // LVS
+            Limit_value_status1 = new JetBusCommand(1, "2020/25", 0, 1);// LVS - limit value status 1
+            Limit_value_status2 = new JetBusCommand(1, "2020/25", 1, 1);// LVS - limit value status 2
+            Limit_value_status3 = new JetBusCommand(1, "2020/25", 2, 1);// LVS - limit value status 3
+            Limit_value_status4 = new JetBusCommand(1, "2020/25", 3, 1);// LVS - limit value status 4
+
             Coarse_flow_monitoring = new JetBusCommand(1, "2210/01", 0, 0);      // CBK = Füllstromüberwachung Grobstrom
             Coarse_flow_monitoring_time = new JetBusCommand(1, "2220/01", 0, 0); // CBT = Überwachungszeit Grobstrom
             Coarse_flow_cut_off_point = new JetBusCommand(1, "2210/02", 0, 0);   // CFD = Grobstromabschaltpunkt
@@ -228,10 +246,25 @@ namespace HBM.Weighing.API.WTX.Jet
         public static JetBusCommand Net_value { get; private set; }
         public static JetBusCommand Gross_value { get; private set; }
         public static JetBusCommand Zero_value { get; private set; }
-
         public static JetBusCommand Tare_value { get; private set; }
+
         public static JetBusCommand Weighing_device_1_weight_status { get; private set; }
         public static JetBusCommand WS_GeneralWeightError { get; private set; }
+        public static JetBusCommand WS_ScaleAlarm { get; private set; }
+        public static JetBusCommand WS_LimitStatus { get; private set; }
+        public static JetBusCommand WS_WeightMoving { get; private set; }
+        public static JetBusCommand WS_ScaleSealIsOpen { get; private set; }
+        public static JetBusCommand WS_ManualTare { get; private set; }
+        public static JetBusCommand WS_WeightType { get; private set; }
+        public static JetBusCommand WS_ScaleRange { get; private set; }
+        public static JetBusCommand WS_ZeroRequired { get; private set; }
+        public static JetBusCommand WS_CenterOfZero { get; private set; }
+        public static JetBusCommand WS_InsideZero { get; private set; }
+        public static JetBusCommand WS_Reserved { get; private set; }
+        public static JetBusCommand WS_ImplementationSpecificWeightStatus1 { get; private set; }
+        public static JetBusCommand WS_ImplementationSpecificWeightStatus2 { get; private set; }
+
+        public static JetBusCommand WS_Unit { get; private set; }
         public static JetBusCommand Unit_prefix_fixed_parameter { get; private set; }
 
         public static JetBusCommand Application_mode { get; private set; } // IMD = Input mode ( Application mode)
@@ -250,7 +283,10 @@ namespace HBM.Weighing.API.WTX.Jet
         public static JetBusCommand Status_digital_output_3 { get; private set; }   // OS3
         public static JetBusCommand Status_digital_output_4 { get; private set; }   // OS4
 
-        public static JetBusCommand Limit_value { get; private set; }   // LVS
+        public static JetBusCommand Limit_value_status1 { get; private set; }   // LVS - limit value status 1
+        public static JetBusCommand Limit_value_status2 { get; private set; }   // LVS - limit value status 2
+        public static JetBusCommand Limit_value_status3 { get; private set; }   // LVS - limit value status 3
+        public static JetBusCommand Limit_value_status4 { get; private set; }   // LVS - limit value status 4
 
         //private string[] _weightMemArray = new string[2] { _storage_weight, _storage_weight_mode };
 

--- a/HBM.Weighing.API/WTX/Modbus/ModbusCommands.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusCommands.cs
@@ -43,9 +43,9 @@ namespace HBM.Weighing.API.WTX.Modbus
     /// The ID's are commited as a parameter for the read and/or write method call.  
     /// This class inherits from interface ICommands. 
     /// </summary>
-    public class ModbusCommands
+    public static class ModbusCommands
     {
-        public ModbusCommands()
+        static ModbusCommands()
         {
             // region : ID Commands : Memory - day, month, year, seqNumber, gross, net
             // For standard mode: 
@@ -188,139 +188,139 @@ namespace HBM.Weighing.API.WTX.Modbus
         // region ID Commands : Memory - day, month, year, seqNumber, gross, net
 
         // For standard mode: 
-        public ModbusCommand WeightMemDayStandard { get; private set; }
-        public ModbusCommand WeightMemMonthStandard { get; private set; }
-        public ModbusCommand WeightMemYearStandard { get; private set; }
-        public ModbusCommand WeightMemSeqNumberStandard { get; private set; }
-        public ModbusCommand WeightMemGrossStandard { get; private set; }
-        public ModbusCommand WeightMemNetStandard { get; private set; }
+        public static  ModbusCommand WeightMemDayStandard { get; private set; }
+        public static  ModbusCommand WeightMemMonthStandard { get; private set; }
+        public static  ModbusCommand WeightMemYearStandard { get; private set; }
+        public static  ModbusCommand WeightMemSeqNumberStandard { get; private set; }
+        public static  ModbusCommand WeightMemGrossStandard { get; private set; }
+        public static  ModbusCommand WeightMemNetStandard { get; private set; }
 
         // For filler mode: 
-        public ModbusCommand WeightMemDayFiller { get; private set; }
-        public ModbusCommand WeightMemMonthFiller { get; private set; }
-        public ModbusCommand WeightMemYearFiller { get; private set; }
-        public ModbusCommand WeightMemSeqNumberFiller { get; private set; }
-        public ModbusCommand WeightMemGrossFiller { get; private set; }
-        public ModbusCommand WeightMemNetFiller { get; private set; }
+        public static  ModbusCommand WeightMemDayFiller { get; private set; }
+        public static  ModbusCommand WeightMemMonthFiller { get; private set; }
+        public static  ModbusCommand WeightMemYearFiller { get; private set; }
+        public static  ModbusCommand WeightMemSeqNumberFiller { get; private set; }
+        public static  ModbusCommand WeightMemGrossFiller { get; private set; }
+        public static  ModbusCommand WeightMemNetFiller { get; private set; }
 
         // region ID Commands : Maintenance - Calibration
 
-        public ModbusCommand LDWZeroSignal { get; private set; }        
-        public ModbusCommand LWTNominalSignal { get; private set; }      
-        public ModbusCommand CWTScaleCalibrationWeight { get; private set; }   
+        public static  ModbusCommand LDWZeroSignal { get; private set; }        
+        public static  ModbusCommand LWTNominalSignal { get; private set; }      
+        public static  ModbusCommand CWTScaleCalibrationWeight { get; private set; }   
 
         // region ID commands for process data
-        public ModbusCommand Net { get; private set; }
-        public ModbusCommand Gross { get; private set; }
-        public ModbusCommand Zero { get; private set; }
-        public ModbusCommand ManualTareValue { get; private set; }  
+        public static  ModbusCommand Net { get; private set; }
+        public static  ModbusCommand Gross { get; private set; }
+        public static  ModbusCommand Zero { get; private set; }
+        public static  ModbusCommand ManualTareValue { get; private set; }  
 
-        public ModbusCommand GeneralWeightError { get; private set; }
-        public ModbusCommand ScaleAlarmTriggered { get; private set; }
-        public ModbusCommand WeightMoving { get; private set; }
-        public ModbusCommand ScaleSealIsOpen { get; private set; }
-        public ModbusCommand ManualTare { get; private set; }
-        public ModbusCommand WeightType { get; private set; }
-        public ModbusCommand ScaleRange { get; private set; }
-        public ModbusCommand ZeroRequired { get; private set; }
-        public ModbusCommand WeightinCenterOfZero { get; private set; }
-        public ModbusCommand WeightinZeroRange { get; private set; }
-        public ModbusCommand Decimals { get; private set; }
-        public ModbusCommand Handshake { get; private set; }
-        public ModbusCommand Limit_status { get; private set; }             
-        public ModbusCommand Unit { get; private set; }   
-        public ModbusCommand Application_mode { get; private set; }            
-        public ModbusCommand Status { get; private set; }    
+        public static  ModbusCommand GeneralWeightError { get; private set; }
+        public static  ModbusCommand ScaleAlarmTriggered { get; private set; }
+        public static  ModbusCommand WeightMoving { get; private set; }
+        public static  ModbusCommand ScaleSealIsOpen { get; private set; }
+        public static  ModbusCommand ManualTare { get; private set; }
+        public static  ModbusCommand WeightType { get; private set; }
+        public static  ModbusCommand ScaleRange { get; private set; }
+        public static  ModbusCommand ZeroRequired { get; private set; }
+        public static  ModbusCommand WeightinCenterOfZero { get; private set; }
+        public static  ModbusCommand WeightinZeroRange { get; private set; }
+        public static  ModbusCommand Decimals { get; private set; }
+        public static  ModbusCommand Handshake { get; private set; }
+        public static  ModbusCommand Limit_status { get; private set; }             
+        public static  ModbusCommand Unit { get; private set; }   
+        public static  ModbusCommand Application_mode { get; private set; }            
+        public static  ModbusCommand Status { get; private set; }    
 
         // region ID commands for standard mode
-        public ModbusCommand Status_digital_input_1 { get; private set; }    // IS1
-        public ModbusCommand Status_digital_input_2 { get; private set; }    // IS2
-        public ModbusCommand Status_digital_input_3 { get; private set; }    // IS3
-        public ModbusCommand Status_digital_input_4 { get; private set; }    // IS4
+        public static  ModbusCommand Status_digital_input_1 { get; private set; }    // IS1
+        public static  ModbusCommand Status_digital_input_2 { get; private set; }    // IS2
+        public static  ModbusCommand Status_digital_input_3 { get; private set; }    // IS3
+        public static  ModbusCommand Status_digital_input_4 { get; private set; }    // IS4
 
-        public ModbusCommand Status_digital_output_1 { get; private set; }   // OS1
-        public ModbusCommand Status_digital_output_2 { get; private set; }   // OS2
-        public ModbusCommand Status_digital_output_3 { get; private set; }   // OS3
-        public ModbusCommand Status_digital_output_4 { get; private set; }   // OS4
+        public static  ModbusCommand Status_digital_output_1 { get; private set; }   // OS1
+        public static  ModbusCommand Status_digital_output_2 { get; private set; }   // OS2
+        public static  ModbusCommand Status_digital_output_3 { get; private set; }   // OS3
+        public static  ModbusCommand Status_digital_output_4 { get; private set; }   // OS4
 
-        public ModbusCommand Limit_value { get; private set; }   // LVS
+        public static  ModbusCommand Limit_value { get; private set; }   // LVS
 
 
-        public ModbusCommand LimitValue1Input { get; private set; } // = Grenzwertüberwachung 
-        public ModbusCommand LimitValue1Mode { get; private set; }
-        public ModbusCommand LimitValue1ActivationLevelLowerBandLimit { get; private set; }        // = Einschaltpegel
-        public ModbusCommand LimitValue1HysteresisBandHeight { get; private set; }       // = Ausschaltpegel
+        public static  ModbusCommand LimitValue1Input { get; private set; } // = Grenzwertüberwachung 
+        public static  ModbusCommand LimitValue1Mode { get; private set; }
+        public static  ModbusCommand LimitValue1ActivationLevelLowerBandLimit { get; private set; }        // = Einschaltpegel
+        public static  ModbusCommand LimitValue1HysteresisBandHeight { get; private set; }       // = Ausschaltpegel
 
-        public ModbusCommand LimitValue2Source { get; private set; }
-        public ModbusCommand LimitValue2Mode { get; private set; }
-        public ModbusCommand LimitValue2ActivationLevelLowerBandLimit { get; private set; }
-        public ModbusCommand LimitValue2HysteresisBandHeight { get; private set; }
+        public static  ModbusCommand LimitValue2Source { get; private set; }
+        public static  ModbusCommand LimitValue2Mode { get; private set; }
+        public static  ModbusCommand LimitValue2ActivationLevelLowerBandLimit { get; private set; }
+        public static  ModbusCommand LimitValue2HysteresisBandHeight { get; private set; }
 
-        public ModbusCommand LimitValue3Source { get; private set; }
-        public ModbusCommand LimitValue3Mode { get; private set; }
-        public ModbusCommand LimitValue3ActivationLevelLowerBandLimit { get; private set; }
-        public ModbusCommand LimitValue3HysteresisBandHeight { get; private set; }
+        public static  ModbusCommand LimitValue3Source { get; private set; }
+        public static  ModbusCommand LimitValue3Mode { get; private set; }
+        public static  ModbusCommand LimitValue3ActivationLevelLowerBandLimit { get; private set; }
+        public static  ModbusCommand LimitValue3HysteresisBandHeight { get; private set; }
 
-        public ModbusCommand LimitValue4Source { get; private set; }
-        public ModbusCommand LimitValue4Mode { get; private set; }
-        public ModbusCommand LimitValue4ActivationLevelLowerBandLimit { get; private set; }
-        public ModbusCommand LimitValue4HysteresisBandHeight { get; private set; }
+        public static  ModbusCommand LimitValue4Source { get; private set; }
+        public static  ModbusCommand LimitValue4Mode { get; private set; }
+        public static  ModbusCommand LimitValue4ActivationLevelLowerBandLimit { get; private set; }
+        public static  ModbusCommand LimitValue4HysteresisBandHeight { get; private set; }
 
         // region ID commands for filler data
 
-        public ModbusCommand CoarseFlow { get; private set; }                // data input word 8, bit .0, application mode=filler
-        public ModbusCommand FineFlow { get; private set; }                 // data input word 8, bit .1, application mode=filler
-        public ModbusCommand Ready { get; private set; }                    // data input word 8, bit .2, application mode=filler
-        public ModbusCommand ReDosing { get; private set; }                 // data input word 8, bit .3, application mode=filler; RDS = Nachdosieren
-        public ModbusCommand Emptying { get; private set; }                 // data input word 8, bit .4, application mode=filler
-        public ModbusCommand FlowError { get; private set; }                // data input word 8, bit .5, application mode=filler
-        public ModbusCommand Alarm { get; private set; }                    // data input word 8, bit .6, application mode=filler
-        public ModbusCommand AdcOverUnderload { get; private set; }         // data input word 8, bit .7, application mode=filler
-        public ModbusCommand MaximalDosingTimeInput { get; private set; }   // data input word 8, bit .8, application mode=filler
-        public ModbusCommand LegalForTradeOperation { get; private set; }   // data input word 8, bit .9, application mode=filler
-        public ModbusCommand ToleranceErrorPlus { get; private set; }       // data input word 8, bit .10, application mode=filler
-        public ModbusCommand ToleranceErrorMinus { get; private set; }      // data input word 8, bit .11, application mode=filler
-        public ModbusCommand StatusInput1 { get; private set; }             // data input word 8, bit .14, application mode=filler
-        public ModbusCommand GeneralScaleError { get; private set; }        // data input word 8, bit .15, application mode=filler
+        public static  ModbusCommand CoarseFlow { get; private set; }                // data input word 8, bit .0, application mode=filler
+        public static  ModbusCommand FineFlow { get; private set; }                 // data input word 8, bit .1, application mode=filler
+        public static  ModbusCommand Ready { get; private set; }                    // data input word 8, bit .2, application mode=filler
+        public static  ModbusCommand ReDosing { get; private set; }                 // data input word 8, bit .3, application mode=filler; RDS = Nachdosieren
+        public static  ModbusCommand Emptying { get; private set; }                 // data input word 8, bit .4, application mode=filler
+        public static  ModbusCommand FlowError { get; private set; }                // data input word 8, bit .5, application mode=filler
+        public static  ModbusCommand Alarm { get; private set; }                    // data input word 8, bit .6, application mode=filler
+        public static  ModbusCommand AdcOverUnderload { get; private set; }         // data input word 8, bit .7, application mode=filler
+        public static  ModbusCommand MaximalDosingTimeInput { get; private set; }   // data input word 8, bit .8, application mode=filler
+        public static  ModbusCommand LegalForTradeOperation { get; private set; }   // data input word 8, bit .9, application mode=filler
+        public static  ModbusCommand ToleranceErrorPlus { get; private set; }       // data input word 8, bit .10, application mode=filler
+        public static  ModbusCommand ToleranceErrorMinus { get; private set; }      // data input word 8, bit .11, application mode=filler
+        public static  ModbusCommand StatusInput1 { get; private set; }             // data input word 8, bit .14, application mode=filler
+        public static  ModbusCommand GeneralScaleError { get; private set; }        // data input word 8, bit .15, application mode=filler
 
-        public ModbusCommand TotalWeight { get; private set; }             // data input word 18, application mode=filler
-        public ModbusCommand Dosing_time { get; private set; }             // DST = Dosieristzeit
-        public ModbusCommand Coarse_flow_time { get; private set; }        // CFT = Grobstromzeit
-        public ModbusCommand CurrentFineFlowTime { get; private set; }     // data input word 26, application mode=filler; FFT = Feinstromzeit
-        public ModbusCommand ParameterSetProduct { get; private set; }     // data input word 27, application mode=filler
-        public ModbusCommand TargetFillingWeight { get; private set; }     // data output word 10, application mode=filler
+        public static  ModbusCommand TotalWeight { get; private set; }             // data input word 18, application mode=filler
+        public static  ModbusCommand Dosing_time { get; private set; }             // DST = Dosieristzeit
+        public static  ModbusCommand Coarse_flow_time { get; private set; }        // CFT = Grobstromzeit
+        public static  ModbusCommand CurrentFineFlowTime { get; private set; }     // data input word 26, application mode=filler; FFT = Feinstromzeit
+        public static  ModbusCommand ParameterSetProduct { get; private set; }     // data input word 27, application mode=filler
+        public static  ModbusCommand TargetFillingWeight { get; private set; }     // data output word 10, application mode=filler
 
-        public ModbusCommand Residual_flow_time { get; private set; }          // RFT = Nachstromzeit
-        public ModbusCommand Reference_value_dosing { get; private set; }      // FWT = Sollwert dosieren = Target filling weight
-        public ModbusCommand Coarse_flow_cut_off_point { get; private set; }   // CFD = Grobstromabschaltpunkt
-        public ModbusCommand Fine_flow_cut_off_point { get; private set; }     // FFD = Feinstromabschaltpunkt
+        public static  ModbusCommand Residual_flow_time { get; private set; }          // RFT = Nachstromzeit
+        public static  ModbusCommand Reference_value_dosing { get; private set; }      // FWT = Sollwert dosieren = Target filling weight
+        public static  ModbusCommand Coarse_flow_cut_off_point { get; private set; }   // CFD = Grobstromabschaltpunkt
+        public static  ModbusCommand Fine_flow_cut_off_point { get; private set; }     // FFD = Feinstromabschaltpunkt
 
-        public ModbusCommand Minimum_fine_flow { get; private set; }           // FFM = Minimaler Feinstromanteil
-        public ModbusCommand Optimization { get; private set; }                // OSN = Optimierung
-        public ModbusCommand Maximal_dosing_time { get; private set; }         // MDT = Maximale Dosierzeit
-        public ModbusCommand Run_start_dosing { get; private set; }            // RUN = Start Dosieren
+        public static  ModbusCommand Minimum_fine_flow { get; private set; }           // FFM = Minimaler Feinstromanteil
+        public static  ModbusCommand Optimization { get; private set; }                // OSN = Optimierung
+        public static  ModbusCommand Maximal_dosing_time { get; private set; }         // MDT = Maximale Dosierzeit
+        public static  ModbusCommand Run_start_dosing { get; private set; }            // RUN = Start Dosieren
 
-        public ModbusCommand Lockout_time_coarse_flow { get; private set; }    // LTC = Sperrzeit Grobstrom
-        public ModbusCommand Lockout_time_fine_flow { get; private set; }      // LTF = Sperrzeit Feinstrom
-        public ModbusCommand Tare_mode { get; private set; }                   // TMD = Tariermodus
-        public ModbusCommand Upper_tolerance_limit { get; private set; }       // UTL = Obere Toleranz
+        public static  ModbusCommand Lockout_time_coarse_flow { get; private set; }    // LTC = Sperrzeit Grobstrom
+        public static  ModbusCommand Lockout_time_fine_flow { get; private set; }      // LTF = Sperrzeit Feinstrom
+        public static  ModbusCommand Tare_mode { get; private set; }                   // TMD = Tariermodus
+        public static  ModbusCommand Upper_tolerance_limit { get; private set; }       // UTL = Obere Toleranz
 
-        public ModbusCommand Lower_tolerance_limit { get; private set; }   // LTL = Untere Toleranz
-        public ModbusCommand Minimum_start_weight { get; private set; }   // MSW = Minimum Startgewicht
-        public ModbusCommand Empty_weight { get; private set; }
-        public ModbusCommand Tare_delay { get; private set; }   // TAD = Tarierverzögerung
+        public static  ModbusCommand Lower_tolerance_limit { get; private set; }   // LTL = Untere Toleranz
+        public static  ModbusCommand Minimum_start_weight { get; private set; }   // MSW = Minimum Startgewicht
+        public static  ModbusCommand Empty_weight { get; private set; }
+        public static  ModbusCommand Tare_delay { get; private set; }   // TAD = Tarierverzögerung
 
-        public ModbusCommand Coarse_flow_monitoring_time { get; private set; }  // CBT = Überwachungszeit Grobstrom
-        public ModbusCommand Coarse_flow_monitoring { get; private set; }       // CBK = Füllstromüberwachung Grobstrom
-        public ModbusCommand Fine_flow_monitoring { get; private set; }         // FBK = Füllstromüberwachung Feinstrom
-        public ModbusCommand Fine_flow_monitoring_time { get; private set; }    // FBT = Überwachungszeit Feinstrom
+        public static  ModbusCommand Coarse_flow_monitoring_time { get; private set; }  // CBT = Überwachungszeit Grobstrom
+        public static  ModbusCommand Coarse_flow_monitoring { get; private set; }       // CBK = Füllstromüberwachung Grobstrom
+        public static  ModbusCommand Fine_flow_monitoring { get; private set; }         // FBK = Füllstromüberwachung Feinstrom
+        public static  ModbusCommand Fine_flow_monitoring_time { get; private set; }    // FBT = Überwachungszeit Feinstrom
 
-        public ModbusCommand Delay_time_after_fine_flow { get; private set; }
-        public ModbusCommand Activation_time_after_fine_flow { get; private set; }
+        public static  ModbusCommand Delay_time_after_fine_flow { get; private set; }
+        public static  ModbusCommand Activation_time_after_fine_flow { get; private set; }
 
-        public ModbusCommand Systematic_difference { get; private set; }       // SYD = Systematische Differenz
-        public ModbusCommand DownwardsDosing { get; private set; }             // data output word 42, application mode=filler
-        public ModbusCommand Valve_control { get; private set; }               // VCT = Ventilsteuerung
-        public ModbusCommand Emptying_mode { get; private set; }               // EMD = Entleermodus
+        public static  ModbusCommand Systematic_difference { get; private set; }       // SYD = Systematische Differenz
+        public static  ModbusCommand DownwardsDosing { get; private set; }             // data output word 42, application mode=filler
+        public static  ModbusCommand Valve_control { get; private set; }               // VCT = Ventilsteuerung
+        public static  ModbusCommand Emptying_mode { get; private set; }               // EMD = Entleermodus
     }
 }

--- a/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
@@ -79,14 +79,12 @@ namespace HBM.Weighing.API.WTX.Modbus
         private Dictionary<ModbusCommand, int> _dataCommandsBuffer = new Dictionary<ModbusCommand, int>();
 
         private int _dataCommand;
-
-        private ModbusCommands _commands;
-
+        
         #endregion
 
         #region Events
         public event EventHandler BusActivityDetection;
-        public event EventHandler<DataEventArgs> UpdateDataClasses;
+        public event EventHandler<EventArgs> UpdateDataClasses;
         public event EventHandler<DataEventArgs> IncomingDataReceived;
         #endregion
 
@@ -97,9 +95,7 @@ namespace HBM.Weighing.API.WTX.Modbus
             _connected = false;
             _port = MODBUS_TCP_DEFAULT_PORT;
             ipAddress = IpAddress; //IP-address to establish a successful connection to the device
-
-            _commands = new ModbusCommands();
-
+            
             this.CreateDictionary();
 
             _dataToWrite = new ushort[2] { 0, 0 };
@@ -216,7 +212,7 @@ namespace HBM.Weighing.API.WTX.Modbus
 
                 this.UpdateDictionary();
                 // Updata data in data classes : 
-                this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
+                this.UpdateDataClasses?.Invoke(this, new EventArgs());
 
                 return _data[Convert.ToInt16(index)];
             }
@@ -236,7 +232,7 @@ namespace HBM.Weighing.API.WTX.Modbus
             this.UpdateDictionary();
 
             // Update data in data classes : 
-            this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
+            this.UpdateDataClasses?.Invoke(this, new EventArgs());
 
             return _data;
         }
@@ -357,11 +353,11 @@ namespace HBM.Weighing.API.WTX.Modbus
         {
             _dataIntegerBuffer.Clear();
 
-            Type pType = _commands.GetType();
+            Type pType = typeof(ModbusCommands); 
             PropertyInfo[] pInfos = pType.GetProperties();
             foreach (PropertyInfo pInfo in pInfos)
             {
-                object propertyValue = pInfo.GetValue(_commands, null);
+                object propertyValue = pInfo.GetValue(typeof(ModbusCommands), null);
                 if (propertyValue != null)
                 {
                     Type propertyValueType = propertyValue.GetType();
@@ -376,57 +372,57 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private void UpdateDictionary()
         {
-            this.GetDataFromDictionary(_commands.Net);
-            this.GetDataFromDictionary(_commands.Gross);
+            this.GetDataFromDictionary(ModbusCommands.Net);
+            this.GetDataFromDictionary(ModbusCommands.Gross);
 
-            this.GetDataFromDictionary(_commands.WeightMoving);
-            this.GetDataFromDictionary(_commands.ScaleSealIsOpen);
-            this.GetDataFromDictionary(_commands.ManualTare);
-            this.GetDataFromDictionary(_commands.Tare_mode);
-            this.GetDataFromDictionary(_commands.ScaleRange);
-            this.GetDataFromDictionary(_commands.ZeroRequired);
-            this.GetDataFromDictionary(_commands.WeightinCenterOfZero);
-            this.GetDataFromDictionary(_commands.WeightinZeroRange);
+            this.GetDataFromDictionary(ModbusCommands.WeightMoving);
+            this.GetDataFromDictionary(ModbusCommands.ScaleSealIsOpen);
+            this.GetDataFromDictionary(ModbusCommands.ManualTare);
+            this.GetDataFromDictionary(ModbusCommands.Tare_mode);
+            this.GetDataFromDictionary(ModbusCommands.ScaleRange);
+            this.GetDataFromDictionary(ModbusCommands.ZeroRequired);
+            this.GetDataFromDictionary(ModbusCommands.WeightinCenterOfZero);
+            this.GetDataFromDictionary(ModbusCommands.WeightinZeroRange);
 
-            this.GetDataFromDictionary(_commands.Application_mode);     // application mode 
-            this.GetDataFromDictionary(_commands.Decimals);             // decimals
-            this.GetDataFromDictionary(_commands.Unit);                 // unit
-            this.GetDataFromDictionary(_commands.Handshake);            // handshake
+            this.GetDataFromDictionary(ModbusCommands.Application_mode);     // application mode 
+            this.GetDataFromDictionary(ModbusCommands.Decimals);             // decimals
+            this.GetDataFromDictionary(ModbusCommands.Unit);                 // unit
+            this.GetDataFromDictionary(ModbusCommands.Handshake);            // handshake
 
-            this.GetDataFromDictionary(_commands.Status_digital_input_1);
-            this.GetDataFromDictionary(_commands.Status_digital_output_1);
-            this.GetDataFromDictionary(_commands.Limit_value);
+            this.GetDataFromDictionary(ModbusCommands.Status_digital_input_1);
+            this.GetDataFromDictionary(ModbusCommands.Status_digital_output_1);
+            this.GetDataFromDictionary(ModbusCommands.Limit_value);
 
-            this.GetDataFromDictionary(_commands.Fine_flow_cut_off_point);
-            this.GetDataFromDictionary(_commands.Coarse_flow_cut_off_point);
-            this.GetDataFromDictionary(_commands.Coarse_flow_monitoring);   
-            this.GetDataFromDictionary(_commands.Fine_flow_monitoring);   
+            this.GetDataFromDictionary(ModbusCommands.Fine_flow_cut_off_point);
+            this.GetDataFromDictionary(ModbusCommands.Coarse_flow_cut_off_point);
+            this.GetDataFromDictionary(ModbusCommands.Coarse_flow_monitoring);   
+            this.GetDataFromDictionary(ModbusCommands.Fine_flow_monitoring);   
 
-            this.GetDataFromDictionary(_commands.Ready);
-            this.GetDataFromDictionary(_commands.ReDosing);
+            this.GetDataFromDictionary(ModbusCommands.Ready);
+            this.GetDataFromDictionary(ModbusCommands.ReDosing);
             
-            //this.GetDataFromDictionary(_commands.Emptying_mode);
-            this.GetDataFromDictionary(_commands.Maximal_dosing_time);
-            this.GetDataFromDictionary(_commands.Upper_tolerance_limit);
-            this.GetDataFromDictionary(_commands.Lower_tolerance_limit);
-            this.GetDataFromDictionary(_commands.StatusInput1);
-            this.GetDataFromDictionary(_commands.LegalForTradeOperation);
+            //this.GetDataFromDictionary(ModbusCommands.Emptying_mode);
+            this.GetDataFromDictionary(ModbusCommands.Maximal_dosing_time);
+            this.GetDataFromDictionary(ModbusCommands.Upper_tolerance_limit);
+            this.GetDataFromDictionary(ModbusCommands.Lower_tolerance_limit);
+            this.GetDataFromDictionary(ModbusCommands.StatusInput1);
+            this.GetDataFromDictionary(ModbusCommands.LegalForTradeOperation);
 
-            this.GetDataFromDictionary(_commands.WeightMemDayStandard);
-            this.GetDataFromDictionary(_commands.WeightMemMonthStandard);
-            this.GetDataFromDictionary(_commands.WeightMemYearStandard);
-            this.GetDataFromDictionary(_commands.WeightMemSeqNumberStandard);
-            this.GetDataFromDictionary(_commands.WeightMemGrossStandard);
-            this.GetDataFromDictionary(_commands.WeightMemNetStandard);
+            this.GetDataFromDictionary(ModbusCommands.WeightMemDayStandard);
+            this.GetDataFromDictionary(ModbusCommands.WeightMemMonthStandard);
+            this.GetDataFromDictionary(ModbusCommands.WeightMemYearStandard);
+            this.GetDataFromDictionary(ModbusCommands.WeightMemSeqNumberStandard);
+            this.GetDataFromDictionary(ModbusCommands.WeightMemGrossStandard);
+            this.GetDataFromDictionary(ModbusCommands.WeightMemNetStandard);
 
-            this.GetDataFromDictionary(_commands.Emptying);
-            this.GetDataFromDictionary(_commands.FlowError);
-            this.GetDataFromDictionary(_commands.Alarm);
-            this.GetDataFromDictionary(_commands.AdcOverUnderload);
+            this.GetDataFromDictionary(ModbusCommands.Emptying);
+            this.GetDataFromDictionary(ModbusCommands.FlowError);
+            this.GetDataFromDictionary(ModbusCommands.Alarm);
+            this.GetDataFromDictionary(ModbusCommands.AdcOverUnderload);
 
-            this.GetDataFromDictionary(_commands.StatusInput1);
-            this.GetDataFromDictionary(_commands.GeneralScaleError);
-            this.GetDataFromDictionary(_commands.TotalWeight);
+            this.GetDataFromDictionary(ModbusCommands.StatusInput1);
+            this.GetDataFromDictionary(ModbusCommands.GeneralScaleError);
+            this.GetDataFromDictionary(ModbusCommands.TotalWeight);
 
             // Undefined IDs:
             /*
@@ -442,14 +438,6 @@ namespace HBM.Weighing.API.WTX.Modbus
             _dataIntegerBuffer[IDCommands.] = _fillingProcessStatus = _data[9];  // Undefined
             _dataIntegerBuffer[IDCommands.] = _numberDosingResults = _data[11];        
             */
-        }
-
-        public ModbusCommands Commands
-        {
-            get
-            {
-                return _commands;
-            }
         }
 
         public Dictionary<string, int> AllData

--- a/Tests/JetbusTest/CalibrationTests.cs
+++ b/Tests/JetbusTest/CalibrationTests.cs
@@ -15,7 +15,7 @@ namespace JetbusTest
     [TestFixture]
     public class CalibrationTests
     {
-        private TestJetbusConnection _jetTestConnection;
+        private INetConnection _jetTestConnection;
         private WTXJet _wtxObj;
         private int testGrossValue;
 
@@ -57,7 +57,7 @@ namespace JetbusTest
             testGrossValue = 0;
         }
     
-        
+        /*
         [Test, TestCaseSource(typeof(CalibrationTests), "CalibrationTestCases")]
         public bool CalibrationTest(Behavior behavior)
         {
@@ -106,7 +106,8 @@ namespace JetbusTest
             else
                 return false;
         }
-
+        */
+        /*
         [Test, TestCaseSource(typeof(CalibrationTests), "CalibrationPreloadCapacityTestCases")]
         public bool CalibrationPreloadCapacityTest(Behavior behavior)
         {
@@ -144,7 +145,7 @@ namespace JetbusTest
             else
                 return false;
         }
-        
+        */
 
         private void OnConnect(bool obj)
         {

--- a/Tests/JetbusTest/CommentMethodsTests.cs
+++ b/Tests/JetbusTest/CommentMethodsTests.cs
@@ -352,7 +352,7 @@ namespace JetbusTest
 
             _wtxObj.Connect(this.OnConnect, 100);
             
-            _wtxObj.ProcessData.UpdateProcessData(this, new DataEventArgs(_jetTestConnection.AllData));
+            _wtxObj.ProcessData.UpdateProcessData(this, new EventArgs());
 
             value = _wtxObj.ProcessData.Unit;
 

--- a/Tests/JetbusTest/TestJetbusConnection.cs
+++ b/Tests/JetbusTest/TestJetbusConnection.cs
@@ -110,7 +110,7 @@ namespace HBM.Weighing.API.WTX.Jet
 
         public event EventHandler BusActivityDetection;
         public event EventHandler<DataEventArgs> IncomingDataReceived;
-        public event EventHandler<DataEventArgs> UpdateDataClasses;
+        public event EventHandler<EventArgs> UpdateDataClasses;
 
         private int _mTimeoutMs;
 

--- a/Tests/ModbusTest/CommentMethodsModbusTests.cs
+++ b/Tests/ModbusTest/CommentMethodsModbusTests.cs
@@ -382,7 +382,7 @@ namespace HBM.Weighing.API.WTX.Modbus
         [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "NetGrossValueStringComment_3D_TestCase_Modbus")]
         public void testModbus_NetGrossValueStringComment_3D(Behavior behavior)
         {
-            TestModbusTCPConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
+            INetConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
             WTXModbus _wtxObj = new WTXModbus(testConnection, 200,update);
             _wtxObj.Connect(this.OnConnect, 100);
 

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -178,11 +178,10 @@ namespace HBM.Weighing.API.WTX.Modbus
         private ushort[] _dataWTX;
 
         public int command;
-        private ModbusCommands _commands;
 
         public event EventHandler BusActivityDetection;
         public event EventHandler<DataEventArgs> IncomingDataReceived;
-        public event EventHandler<DataEventArgs> UpdateDataClasses;
+        public event EventHandler<EventArgs> UpdateDataClasses;
         
         private Dictionary<string, int> _dataIntegerBuffer;
 
@@ -201,8 +200,6 @@ namespace HBM.Weighing.API.WTX.Modbus
         {
             _dataWTX = new ushort[38];
             // size of 38 elements for the standard and filler application mode.            
-
-            _commands = new ModbusCommands();
 
              _dataIntegerBuffer = new Dictionary<string, int>();
 
@@ -279,109 +276,109 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private void CreateDictionary()
         {
-            _dataIntegerBuffer.Add(_commands.Net.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Gross.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Net.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Gross.Path, 0);
             
-            _dataIntegerBuffer.Add(_commands.Unit.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Unit.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Fine_flow_cut_off_point.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_cut_off_point.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Decimals.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Application_mode.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Scale_command_status.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Fine_flow_cut_off_point.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Coarse_flow_cut_off_point.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Decimals.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Application_mode.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Scale_command_status.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Status_digital_input_1.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_input_2.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_input_3.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_input_4.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Status_digital_input_1.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Status_digital_input_2.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Status_digital_input_3.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Status_digital_input_4.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Status_digital_output_1.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_output_2.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_output_3.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.Status_digital_output_4.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Status_digital_output_1.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Status_digital_output_2.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Status_digital_output_3.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.Status_digital_output_4.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Limit_value.Path, 0);
             /*
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv11.Path, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv12.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv13.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv14.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Limit_value_monitoring_liv11.Path, 0); ;
+            _dataIntegerBuffer.Add(ModbusCommands.Signal_source_liv12.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_on_level_liv13.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_off_level_liv14.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv21.Path, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv22.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv23.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv24.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Limit_value_monitoring_liv21.Path, 0); ;
+            _dataIntegerBuffer.Add(ModbusCommands.Signal_source_liv22.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_on_level_liv23.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_off_level_liv24.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv31.Path, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv32.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv33.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv34.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Limit_value_monitoring_liv31.Path, 0); ;
+            _dataIntegerBuffer.Add(ModbusCommands.Signal_source_liv32.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_on_level_liv33.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_off_level_liv34.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Limit_value_monitoring_liv41.Path, 0); ;
-            _dataIntegerBuffer.Add(_commands.Signal_source_liv42.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_on_level_liv43.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Switch_off_level_liv44.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Limit_value_monitoring_liv41.Path, 0); ;
+            _dataIntegerBuffer.Add(ModbusCommands.Signal_source_liv42.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_on_level_liv43.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Switch_off_level_liv44.Path, 0);
             */
 
-            _dataIntegerBuffer.Add(_commands.WeightMemDayStandard.Path, 0);
-            _dataIntegerBuffer.Add(_commands.WeightMemMonthStandard.Path, 0);
-            _dataIntegerBuffer.Add(_commands.WeightMemYearStandard.Path, 0);
-            _dataIntegerBuffer.Add(_commands.WeightMemSeqNumberStandard.Path, 0);
-            _dataIntegerBuffer.Add(_commands.WeightMemGrossStandard.Path, 0);
-            _dataIntegerBuffer.Add(_commands.WeightMemNetStandard.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.WeightMemDayStandard.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.WeightMemMonthStandard.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.WeightMemYearStandard.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.WeightMemSeqNumberStandard.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.WeightMemGrossStandard.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.WeightMemNetStandard.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Residual_flow_time.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Minimum_fine_flow.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Optimization.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Tare_mode.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Minimum_start_weight.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Tare_delay.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring_time.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring_time.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Systematic_difference.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Valve_control.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.AdcOverUnderload.Path, 0);
-            //_dataIntegerBuffer.Add(_commands.LegalForTradeOperation.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Residual_flow_time.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Minimum_fine_flow.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Optimization.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Tare_mode.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Minimum_start_weight.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Tare_delay.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Coarse_flow_monitoring_time.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Fine_flow_monitoring_time.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Systematic_difference.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Valve_control.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.AdcOverUnderload.Path, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.LegalForTradeOperation.Path, 0);
             /*
-            _dataIntegerBuffer.Add(_commands.StatusInput1.Path, 0);
-            _dataIntegerBuffer.Add(_commands.GeneralScaleError.Path, 0);
-            _dataIntegerBuffer.Add(_commands.CoarseFlow.Path, 0);
-            _dataIntegerBuffer.Add(_commands.FineFlow.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Ready.Path, 0);
-            _dataIntegerBuffer.Add(_commands.ReDosing.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Emptying.Path, 0);
-            _dataIntegerBuffer.Add(_commands.FlowError.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.StatusInput1.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.GeneralScaleError.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.CoarseFlow.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.FineFlow.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Ready.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.ReDosing.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Emptying.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.FlowError.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Alarm.Path, 0);
-            _dataIntegerBuffer.Add(_commands.ToleranceErrorPlus.Path, 0);
-            _dataIntegerBuffer.Add(_commands.ToleranceErrorMinus.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Dosing_time.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_time.Path, 0);
-            _dataIntegerBuffer.Add(_commands.CurrentFineFlowTime.Path, 0);
-            _dataIntegerBuffer.Add(_commands.ParameterSetProduct.Path, 0);
-            _dataIntegerBuffer.Add(_commands.DownwardsDosing.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Alarm.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.ToleranceErrorPlus.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.ToleranceErrorMinus.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Dosing_time.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Coarse_flow_time.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.CurrentFineFlowTime.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.ParameterSetProduct.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.DownwardsDosing.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.TotalWeight.Path, 0);
-            _dataIntegerBuffer.Add(_commands.TargetFillingWeight.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Run_start_dosing.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.TotalWeight.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.TargetFillingWeight.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Run_start_dosing.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Coarse_flow_monitoring.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Fine_flow_monitoring.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Emptying_mode.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Maximal_dosing_time.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Coarse_flow_monitoring.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Fine_flow_monitoring.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Emptying_mode.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Maximal_dosing_time.Path, 0);
 
-            _dataIntegerBuffer.Add(_commands.Upper_tolerance_limit.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Lower_tolerance_limit.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Upper_tolerance_limit.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Lower_tolerance_limit.Path, 0);
 
-            //_dataIntegerBuffer.Add(_commands.IDCommands.RANGE_SELECTION_PARAMETER, 0);
+            //_dataIntegerBuffer.Add(ModbusCommands.IDCommands.RANGE_SELECTION_PARAMETER, 0);
 
-            _dataIntegerBuffer.Add(_commands.Delay_time_after_fine_flow.Path, 0);
-            _dataIntegerBuffer.Add(_commands.Activation_time_after_fine_flow.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Delay_time_after_fine_flow.Path, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.Activation_time_after_fine_flow.Path, 0);
             */
             // Undefined IDs : 
             /*
-            _dataIntegerBuffer.Add(_commands.DOSING_STATE, 0);
-            _dataIntegerBuffer.Add(_commands.DOSING_RESULT, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.DOSING_STATE, 0);
+            _dataIntegerBuffer.Add(ModbusCommands.DOSING_RESULT, 0);
             _dataIntegerBuffer.Add(IDCommands.DELAY1_DOSING, 0);
             _dataIntegerBuffer.Add(IDCommands.STANDARD_DEVIATION, 0);
             _dataIntegerBuffer.Add(IDCommands.EMPTY_WEIGHT_TOLERANCE, 0);
@@ -392,29 +389,29 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         private void UpdateDictionary()
         {
-            _dataIntegerBuffer[_commands.Net.Path] = _data[1] + (_data[0] << 16);
-            _dataIntegerBuffer[_commands.Gross.Path] = _data[3] + (_data[2] << 16);
-            _dataIntegerBuffer[_commands.Status_digital_input_1.Path] = _data[6];
-            _dataIntegerBuffer[_commands.Status_digital_output_1.Path] = _data[7];
-            _dataIntegerBuffer[_commands.Limit_value.Path] = _data[8];
-            _dataIntegerBuffer[_commands.Fine_flow_cut_off_point.Path] = _data[20];
-            _dataIntegerBuffer[_commands.Coarse_flow_cut_off_point.Path] = _data[22];
+            _dataIntegerBuffer[ModbusCommands.Net.Path] = _data[1] + (_data[0] << 16);
+            _dataIntegerBuffer[ModbusCommands.Gross.Path] = _data[3] + (_data[2] << 16);
+            _dataIntegerBuffer[ModbusCommands.Status_digital_input_1.Path] = _data[6];
+            _dataIntegerBuffer[ModbusCommands.Status_digital_output_1.Path] = _data[7];
+            _dataIntegerBuffer[ModbusCommands.Limit_value.Path] = _data[8];
+            _dataIntegerBuffer[ModbusCommands.Fine_flow_cut_off_point.Path] = _data[20];
+            _dataIntegerBuffer[ModbusCommands.Coarse_flow_cut_off_point.Path] = _data[22];
 
-            _dataIntegerBuffer[_commands.Application_mode.Path] = _data[5] & 0x1;             // application mode 
-            _dataIntegerBuffer[_commands.Decimals.Path] = (_data[5] & 0x70) >> 4;     // decimals
-            _dataIntegerBuffer[_commands.Unit.Path] = (_data[5] & 0x180) >> 7;    // unit
+            _dataIntegerBuffer[ModbusCommands.Application_mode.Path] = _data[5] & 0x1;             // application mode 
+            _dataIntegerBuffer[ModbusCommands.Decimals.Path] = (_data[5] & 0x70) >> 4;     // decimals
+            _dataIntegerBuffer[ModbusCommands.Unit.Path] = (_data[5] & 0x180) >> 7;    // unit
 
-            _dataIntegerBuffer[_commands.Coarse_flow_monitoring.Path] = _data[8] & 0x1;           //_coarseFlow
-            _dataIntegerBuffer[_commands.Fine_flow_monitoring.Path] = ((_data[8] & 0x2) >> 1);  // _fineFlow
+            _dataIntegerBuffer[ModbusCommands.Coarse_flow_monitoring.Path] = _data[8] & 0x1;           //_coarseFlow
+            _dataIntegerBuffer[ModbusCommands.Fine_flow_monitoring.Path] = ((_data[8] & 0x2) >> 1);  // _fineFlow
 
-            _dataIntegerBuffer[_commands.Ready.Path] = ((_data[8] & 0x4) >> 2);
-            _dataIntegerBuffer[_commands.ReDosing.Path] = ((_data[8] & 0x8) >> 3);
-            _dataIntegerBuffer[_commands.Emptying_mode.Path] = ((_data[8] & 0x10) >> 4);
-            _dataIntegerBuffer[_commands.Maximal_dosing_time.Path] = ((_data[8] & 0x100) >> 8);
-            _dataIntegerBuffer[_commands.Upper_tolerance_limit.Path] = ((_data[8] & 0x400) >> 10);
-            _dataIntegerBuffer[_commands.Lower_tolerance_limit.Path] = ((_data[8] & 0x800) >> 11);
-            _dataIntegerBuffer[_commands.Status_digital_input_1.Path] = ((_data[8] & 0x4000) >> 14);
-            _dataIntegerBuffer[_commands.LegalForTradeOperation.Path] = ((_data[8] & 0x200) >> 9);
+            _dataIntegerBuffer[ModbusCommands.Ready.Path] = ((_data[8] & 0x4) >> 2);
+            _dataIntegerBuffer[ModbusCommands.ReDosing.Path] = ((_data[8] & 0x8) >> 3);
+            _dataIntegerBuffer[ModbusCommands.Emptying_mode.Path] = ((_data[8] & 0x10) >> 4);
+            _dataIntegerBuffer[ModbusCommands.Maximal_dosing_time.Path] = ((_data[8] & 0x100) >> 8);
+            _dataIntegerBuffer[ModbusCommands.Upper_tolerance_limit.Path] = ((_data[8] & 0x400) >> 10);
+            _dataIntegerBuffer[ModbusCommands.Lower_tolerance_limit.Path] = ((_data[8] & 0x800) >> 11);
+            _dataIntegerBuffer[ModbusCommands.Status_digital_input_1.Path] = ((_data[8] & 0x4000) >> 14);
+            _dataIntegerBuffer[ModbusCommands.LegalForTradeOperation.Path] = ((_data[8] & 0x200) >> 9);
 
             /*
             _dataIntegerBuffer[IDCommands.DOSING_RESULT]      = _data[12];
@@ -427,21 +424,21 @@ namespace HBM.Weighing.API.WTX.Modbus
             _dataIntegerBuffer[IDCommands.RANGE_SELECTION_PARAMETER] = _data[27];     // _parameterSetProduct
             */
 
-            _dataIntegerBuffer[_commands.WeightMemDayStandard.Path] = (_data[9]);   // = weightMemDay
-            _dataIntegerBuffer[_commands.WeightMemMonthStandard.Path] = (_data[10]);  // = weightMemMonth
-            _dataIntegerBuffer[_commands.WeightMemYearStandard.Path] = (_data[11]);  // = weightMemYear
-            _dataIntegerBuffer[_commands.WeightMemSeqNumberStandard.Path] = (_data[12]);  // = weightMemSeqNumber
-            _dataIntegerBuffer[_commands.WeightMemGrossStandard.Path] = (_data[13]);  // = weightMemGross
-            _dataIntegerBuffer[_commands.WeightMemNetStandard.Path] = (_data[14]);  // = weightMemNet
+            _dataIntegerBuffer[ModbusCommands.WeightMemDayStandard.Path] = (_data[9]);   // = weightMemDay
+            _dataIntegerBuffer[ModbusCommands.WeightMemMonthStandard.Path] = (_data[10]);  // = weightMemMonth
+            _dataIntegerBuffer[ModbusCommands.WeightMemYearStandard.Path] = (_data[11]);  // = weightMemYear
+            _dataIntegerBuffer[ModbusCommands.WeightMemSeqNumberStandard.Path] = (_data[12]);  // = weightMemSeqNumber
+            _dataIntegerBuffer[ModbusCommands.WeightMemGrossStandard.Path] = (_data[13]);  // = weightMemGross
+            _dataIntegerBuffer[ModbusCommands.WeightMemNetStandard.Path] = (_data[14]);  // = weightMemNet
 
-            _dataIntegerBuffer[_commands.Emptying.Path] = ((_data[8] & 0x10) >> 4);
-            _dataIntegerBuffer[_commands.FlowError.Path] = ((_data[8] & 0x20) >> 5);
-            _dataIntegerBuffer[_commands.Alarm.Path] = ((_data[8] & 0x40) >> 6);
-            _dataIntegerBuffer[_commands.AdcOverUnderload.Path] = ((_data[8] & 0x80) >> 7);
+            _dataIntegerBuffer[ModbusCommands.Emptying.Path] = ((_data[8] & 0x10) >> 4);
+            _dataIntegerBuffer[ModbusCommands.FlowError.Path] = ((_data[8] & 0x20) >> 5);
+            _dataIntegerBuffer[ModbusCommands.Alarm.Path] = ((_data[8] & 0x40) >> 6);
+            _dataIntegerBuffer[ModbusCommands.AdcOverUnderload.Path] = ((_data[8] & 0x80) >> 7);
 
-            _dataIntegerBuffer[_commands.StatusInput1.Path] = ((_data[8] & 0x4000) >> 14);
-            _dataIntegerBuffer[_commands.GeneralScaleError.Path] = ((_data[8] & 0x8000) >> 15);
-            _dataIntegerBuffer[_commands.TotalWeight.Path] = _data[18];
+            _dataIntegerBuffer[ModbusCommands.StatusInput1.Path] = ((_data[8] & 0x4000) >> 14);
+            _dataIntegerBuffer[ModbusCommands.GeneralScaleError.Path] = ((_data[8] & 0x8000) >> 15);
+            _dataIntegerBuffer[ModbusCommands.TotalWeight.Path] = _data[18];
 
             // Filler data: Missing ID's
             /*
@@ -615,7 +612,7 @@ namespace HBM.Weighing.API.WTX.Modbus
 
             this.UpdateDictionary();
             // Updata data in data classes : 
-            this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
+            this.UpdateDataClasses?.Invoke(this, new EventArgs());
 
             return _dataWTX[Convert.ToInt16(index)];
         }
@@ -1098,7 +1095,7 @@ namespace HBM.Weighing.API.WTX.Modbus
             
                 this.UpdateDictionary();
                 // Update data in data classes : 
-                this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
+                this.UpdateDataClasses?.Invoke(this, new EventArgs());
 
                 return _dataWTX;
 
@@ -1106,7 +1103,7 @@ namespace HBM.Weighing.API.WTX.Modbus
 
             this.UpdateDictionary();
             // Update data in data classes : 
-            this.UpdateDataClasses?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
+            this.UpdateDataClasses?.Invoke(this, new EventArgs());
 
             return _dataWTX;
         }


### PR DESCRIPTION
Using GetData method in all data classes.
Using only EventArgs as eventhandler instead of DataEventArgs in Data classes.
Adding JetBusCommands for weight status and limit value in Jet DataStandard class.
Changing class ModbusCommands to static.