### PR TITLE
Use ReadSingle(index) in TestModbus ; Delete JetBusData property in ModbusTcpConnection ; Delete ConvertJTokenToStringArray() call in JetBusConnection

### DIFF
--- a/HBM.Weighing.API/INetConnection.cs
+++ b/HBM.Weighing.API/INetConnection.cs
@@ -74,16 +74,13 @@ namespace HBM.Weighing.API
 
         #region Read/Write methods
 
-        //int Read(object index);
-
-        void Write(string register, DataType dataType, int value);
-
         Task<ushort[]> ReadAsync();                              // For reading asynchronously
 
         Task<int> WriteAsync(ushort index, ushort commandParam); // For writing asynchronously
         
-        int GetDataFromDictionary(object command); 
+        int GetDataFromDictionary(object command);
 
+        void Write(string register, DataType dataType, int value);
         #endregion
 
     }

--- a/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
@@ -116,8 +116,6 @@ namespace HBM.Weighing.API.WTX.Jet
             ConnectPeer(this._user, this._password, this._timeoutMs);
             FetchAll();          
         }
-
-
         public void DisconnectDevice()
         {
             _peer.Disconnect();
@@ -235,7 +233,6 @@ namespace HBM.Weighing.API.WTX.Jet
         {
             if (!_mSuccessEvent.WaitOne(_timeoutMs * timeoutMultiplier))
             {
-
                 this._connected = false;
 
                 // Timeout-Exception
@@ -249,8 +246,7 @@ namespace HBM.Weighing.API.WTX.Jet
                 Exception exception = _mException;
                 _mException = null;
                 throw exception;
-            }            
-            
+            }                        
         }
 
         public int GetDataFromDictionary(object command)
@@ -350,8 +346,6 @@ namespace HBM.Weighing.API.WTX.Jet
                         break;
                 }
 
-                this.ConvertJTokenToStringArray();
-
                 if (dataArrived == true)
                 {
                     IncomingDataReceived?.Invoke(this, new DataEventArgs(this._dataIntegerBuffer));
@@ -368,38 +362,18 @@ namespace HBM.Weighing.API.WTX.Jet
         /// <returns></returns>
         protected virtual JToken ReadObj(object index) {
 
-            //lock (_dataJTokenBuffer)
-
-                //if (_dataJTokenBuffer.ContainsKey(index.ToString())) {
-
-                    this.ConvertJTokenToStringArray();
-
-                    //IncomingDataReceived?.Invoke(this, null);
-
-                return _dataJTokenBuffer[index.ToString()];
-                /*}
+            lock (_dataJTokenBuffer)
+                if (_dataJTokenBuffer.ContainsKey(index.ToString()))
+                {
+                    return _dataJTokenBuffer[index.ToString()];
+                }
                 else
                 {
-
                     throw new Exception("Object does not exist in the object dictionary");
                 }
-                */
         }
 
-        private void ConvertJTokenToStringArray()
-        {
-            JTokenArray = _dataJTokenBuffer.Values.ToArray();
-            DataUshortArray = new ushort[JTokenArray.Length];
-            DataStrArray = new string[JTokenArray.Length];
-
-            for (int i = 0; i < JTokenArray.Length; i++)
-            {
-                JToken JTokenElement = JTokenArray[i];
-
-                DataStrArray[i] = JTokenElement.ToString();
-            }
-        }
-       
+      
         public int Read(object index)
         {
             try
@@ -498,7 +472,7 @@ namespace HBM.Weighing.API.WTX.Jet
         #endregion
 
         
-        public string BufferToString()
+        private string BufferToString()
         {
             StringBuilder sb = new StringBuilder();
             lock (_dataJTokenBuffer) {
@@ -509,6 +483,19 @@ namespace HBM.Weighing.API.WTX.Jet
                 }
             }
             return sb.ToString();
+        }
+        private void ConvertJTokenToStringArray()
+        {
+            JTokenArray = _dataJTokenBuffer.Values.ToArray();
+            DataUshortArray = new ushort[JTokenArray.Length];
+            DataStrArray = new string[JTokenArray.Length];
+
+            for (int i = 0; i < JTokenArray.Length; i++)
+            {
+                JToken JTokenElement = JTokenArray[i];
+
+                DataStrArray[i] = JTokenElement.ToString();
+            }
         }
 
         public Task<int> WriteAsync(ushort index, ushort commandParam)

--- a/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
+++ b/HBM.Weighing.API/WTX/Modbus/ModbusTCPConnection.cs
@@ -293,14 +293,6 @@ namespace HBM.Weighing.API.WTX.Modbus
             }
         }
 
-        public Dictionary<JetBusCommand, int> JetBusData
-        {
-            get
-            {
-                return new Dictionary<JetBusCommand, int>();
-            }
-        }
-
         #endregion
 
     }

--- a/Tests/ModbusTest/CommentMethodsModbusTests.cs
+++ b/Tests/ModbusTest/CommentMethodsModbusTests.cs
@@ -271,13 +271,17 @@ namespace HBM.Weighing.API.WTX.Modbus
         [TestCaseSource(typeof(CommentMethodsModbusTests), "NetGrossValueStringComment_4D_TestCase_Modbus")]
         [TestCaseSource(typeof(CommentMethodsModbusTests), "NetGrossValueStringComment_5D_TestCase_Modbus")]
         [TestCaseSource(typeof(CommentMethodsModbusTests), "NetGrossValueStringComment_6D_TestCase_Modbus")]
-        public string testModbus_NetGrossValueStringComment(Behavior behavior)
+        public async Task<string> testModbus_NetGrossValueStringComment(Behavior behavior)
         {
-            INetConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
+            TestModbusTCPConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
             WTXModbus _wtxObj = new WTXModbus(testConnection, 200, update);
             _wtxObj.Connect(this.OnConnect, 100);
 
-            int i = _wtxObj.Connection.Read(0);
+            await Task.Run(async () =>
+            {
+                ushort[] result = await testConnection.ReadAsync();
+                _wtxObj.OnData(result);
+            });
 
             string strValue = _wtxObj.PrintableWeight.Net;
 
@@ -286,7 +290,10 @@ namespace HBM.Weighing.API.WTX.Modbus
 
         
         [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "T_UnitValueTestCases")]
-        public async Task<int> testUnit_t(Behavior behavior)
+        [TestCaseSource(typeof(CommentMethodsModbusTests), "KG_UnitValueTestCases")]
+        [TestCaseSource(typeof(CommentMethodsModbusTests), "G_UnitValueTestCases")]
+        [TestCaseSource(typeof(CommentMethodsModbusTests), "LB_UnitValueTestCases")]
+        public async Task<int> testModbus_Unit(Behavior behavior)
         {
             TestModbusTCPConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
 
@@ -304,58 +311,6 @@ namespace HBM.Weighing.API.WTX.Modbus
             return _wtxObj.ProcessData.Unit;
         }
 
-        [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "KG_UnitValueTestCases")]
-        public async Task<int> testUnit_kg(Behavior behavior)
-        {
-            TestModbusTCPConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-
-            WTXModbus _wtxObj = new WTXModbus(testConnection, 200,update);
-
-            _wtxObj.Connect(this.OnConnect, 100);
-
-            await Task.Run(async () =>
-            {
-                ushort[] result = await testConnection.ReadAsync();
-                _wtxObj.OnData(result);
-            });
-
-            return _wtxObj.ProcessData.Unit;
-        }
-
-        [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "G_UnitValueTestCases")]
-        public async Task<int> testUnit_g(Behavior behavior)
-        {
-            TestModbusTCPConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-
-            WTXModbus _wtxObj = new WTXModbus(testConnection, 200,update);
-
-            _wtxObj.Connect(this.OnConnect, 100);
-
-            await Task.Run(async () =>
-            {
-                ushort[] result = await testConnection.ReadAsync();
-                _wtxObj.OnData(result);
-            });
-
-            return _wtxObj.ProcessData.Unit;
-        }
-
-        [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "LB_UnitValueTestCases")]
-        public async Task<int> testUnit_lb(Behavior behavior)
-        {
-            TestModbusTCPConnection testConnection = new TestModbusTCPConnection(behavior, "172.19.103.8");
-            WTXModbus _wtxObj = new WTXModbus(testConnection, 200,update);
-            _wtxObj.Connect(this.OnConnect, 100);
-
-            await Task.Run(async () =>
-            {
-                ushort[] result = await testConnection.ReadAsync();
-                _wtxObj.OnData(result);
-            });
-
-            return _wtxObj.ProcessData.Unit;
-        }
-        
         /*
         [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "ScaleRangeStringComment_Range1_TestCase_Modbus")]
         //public async Task<string> testModbus_ScaleRangeStringComment_Range1(Behavior behavior)

--- a/Tests/ModbusTest/TestModbusTCPConnection.cs
+++ b/Tests/ModbusTest/TestModbusTCPConnection.cs
@@ -367,7 +367,7 @@ namespace HBM.Weighing.API.WTX.Modbus
         }
 
 
-        public int Read(object index)
+        public int ReadSingle(object index)
         {
             switch (this.behavior)
             {
@@ -450,42 +450,6 @@ namespace HBM.Weighing.API.WTX.Modbus
                     else if (_dataWTX[5] >> 14 == 1)
                         _dataWTX[5] = 0x0000;
 
-                    break;
-
-                case Behavior.NetGrossValueStringComment_0D_Success:
-                    _dataWTX[5] = 0x0000;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_0D_Fail:
-                    _dataWTX[5] = 0x60;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_1D_Success:
-                    _dataWTX[5] = 0x10;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_2D_Success:
-                    _dataWTX[5] = 0x20;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_3D_Success:
-                    _dataWTX[5] = 0x30;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_3D_Fail:
-                    _dataWTX[5] = 0x00;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_4D_Success:
-                    _dataWTX[5] = 0x40;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_5D_Success:
-                    _dataWTX[5] = 0x50;
-                    break;
-
-                case Behavior.NetGrossValueStringComment_6D_Success:
-                    _dataWTX[5] = 0x60;
                     break;
                     
                 case Behavior.WriteSyncSuccess:
@@ -882,9 +846,47 @@ namespace HBM.Weighing.API.WTX.Modbus
                     BusActivityDetection?.Invoke(this, _logObj);
                     break;
 
-                // Simulate for testing 'Unit': 
 
-                case Behavior.t_UnitValue_Success:
+                    case Behavior.NetGrossValueStringComment_0D_Success:
+                        _dataWTX[5] = 0x0000;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_0D_Fail:
+                        _dataWTX[5] = 0x60;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_1D_Success:
+                        _dataWTX[5] = 0x10;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_2D_Success:
+                        _dataWTX[5] = 0x20;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_3D_Success:
+                        _dataWTX[5] = 0x30;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_3D_Fail:
+                        _dataWTX[5] = 0x00;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_4D_Success:
+                        _dataWTX[5] = 0x40;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_5D_Success:
+                        _dataWTX[5] = 0x50;
+                        break;
+
+                    case Behavior.NetGrossValueStringComment_6D_Success:
+                        _dataWTX[5] = 0x60;
+                        break;
+
+
+                    // Simulate for testing 'Unit': 
+
+                    case Behavior.t_UnitValue_Success:
                     _dataWTX[5] = 0x100;
                     break;
                 case Behavior.t_UnitValue_Fail:


### PR DESCRIPTION
Use ReadSingle(index) in TestModbus ; 

Delete JetBusData property in ModbusTcpConnection ; 

Delete ConvertJTokenToStringArray() call in JetBusConnection