### PR TITLE
WTXJet : Calibration correction ; JetBusConnection : ReadSingle() parameter cast & access to 'PathIndex'

### DIFF
--- a/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
+++ b/HBM.Weighing.API/WTX/Jet/JetBusConnection.cs
@@ -257,7 +257,7 @@ namespace HBM.Weighing.API.WTX.Jet
 
             try
             {
-                JetBusCommand jetcommand = command as JetBusCommand;
+                JetBusCommand jetcommand = (JetBusCommand)command;
 
                 Console.WriteLine(jetcommand.PathIndex); //DDD
 
@@ -372,13 +372,14 @@ namespace HBM.Weighing.API.WTX.Jet
                     throw new Exception("Object does not exist in the object dictionary");
                 }
         }
-
       
-        public int ReadSingle(object index)
+        public int ReadSingle(object command)
         {
+            JetBusCommand _command = (JetBusCommand)command;
+
             try
             {
-                return Convert.ToInt32(ReadObj(index));
+                return Convert.ToInt32(ReadObj(_command.PathIndex));
             }
             catch (FormatException)
             {

--- a/HBM.Weighing.API/WTX/WTXJet.cs
+++ b/HBM.Weighing.API/WTX/WTXJet.cs
@@ -313,10 +313,10 @@ namespace HBM.Weighing.API.WTX
             Connection.Write(JetBusCommands.Scale_command, SCALE_COMMAND_CALIBRATE_ZERO);       // SCALE_COMMAND = "6002/01"
 
             // check : command "on go" = command is in execution
-            while (Connection.GetDataFromDictionary(JetBusCommands.Scale_command_status.PathIndex) != SCALE_COMMAND_STATUS_ONGOING);
+            while (Connection.ReadSingle(JetBusCommands.Scale_command_status) != SCALE_COMMAND_STATUS_ONGOING);
 
             // check : command "ok" = command is done
-            while (Connection.GetDataFromDictionary(JetBusCommands.Scale_command_status.PathIndex) != SCALE_COMMAND_STATUS_OK);
+            while (Connection.ReadSingle(JetBusCommands.Scale_command_status) != SCALE_COMMAND_STATUS_OK);
             
         }
 
@@ -328,12 +328,10 @@ namespace HBM.Weighing.API.WTX
             Connection.Write(JetBusCommands.Scale_command, SCALE_COMMAND_CALIBRATE_NOMINAL);  // CALIBRATE_NOMINAL_WEIGHT = 1852596579 // SCALE_COMMAND = "6002/01"
 
             // check : command "on go" = command is in execution
-            while (Connection.GetDataFromDictionary(JetBusCommands.Scale_command_status.PathIndex) != SCALE_COMMAND_STATUS_ONGOING) ;      // ID_keys.SCALE_COMMAND_STATUS = 6002/02
+            while (Connection.ReadSingle(JetBusCommands.Scale_command_status) != SCALE_COMMAND_STATUS_ONGOING) ;      // ID_keys.SCALE_COMMAND_STATUS = 6002/02
 
             // check : command "ok" = command is done
-            while (Connection.GetDataFromDictionary(JetBusCommands.Scale_command_status.PathIndex) != SCALE_COMMAND_STATUS_OK) ;     
-
-            //this._isCalibrating = true;
+            while (Connection.ReadSingle(JetBusCommands.Scale_command_status) != SCALE_COMMAND_STATUS_OK) ;     
         }
 
         public override void AdjustNominalSignal()


### PR DESCRIPTION
-WTXJet : Calibration correction ( using ReadSingle(object command) for polling , not GetDataFromDictionary(..) )

-JetBusConnection : ReadSingle (..) parameter cast from object to JetBusCommand & access attribute 'PathIndex'.