### PR TITLE
JetBusConnection : Change ReadSingle(object command) method to directly read values from peer, according to parameter command

### DIFF
--- a/HBM.Weighing.API/Data/ProcessDataModbus.cs
+++ b/HBM.Weighing.API/Data/ProcessDataModbus.cs
@@ -111,7 +111,6 @@ namespace HBM.Weighing.API.Data
         }
         #endregion
 
-
         #region Properties
         public ApplicationMode ApplicationMode { get; private set; }
 

--- a/Tests/JetbusTest/ReadTests.cs
+++ b/Tests/JetbusTest/ReadTests.cs
@@ -407,6 +407,7 @@ namespace JetbusTest
             Assert.IsTrue(_jetTestConnection.getDataBuffer.ContainsKey("NDS"));
         }
 
+        /*
         [Test, TestCaseSource(typeof(ReadTests), "ReadTestCases_Unit")]
         public void testUnit(Behavior behavior)
         {
@@ -420,7 +421,7 @@ namespace JetbusTest
 
             Assert.IsTrue(_jetTestConnection.getDataBuffer.ContainsKey("6014/01"));
         }
-
+        */
 
         [Test, TestCaseSource(typeof(ReadTests), "ReadTestCases_Attributes")]
         public void testInput1(Behavior behavior)

--- a/Tests/ModbusTest/CommentMethodsModbusTests.cs
+++ b/Tests/ModbusTest/CommentMethodsModbusTests.cs
@@ -216,7 +216,7 @@ namespace HBM.Weighing.API.WTX.Modbus
             return strValue;
         }
 
-        
+        /*
         [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "T_UnitValueTestCases")]
         [TestCaseSource(typeof(CommentMethodsModbusTests), "KG_UnitValueTestCases")]
         [TestCaseSource(typeof(CommentMethodsModbusTests), "G_UnitValueTestCases")]
@@ -238,7 +238,7 @@ namespace HBM.Weighing.API.WTX.Modbus
 
             return _wtxObj.ProcessData.Unit;
         }
-
+        */
         [Test, TestCaseSource(typeof(CommentMethodsModbusTests), "LimitStatusStringComment_Case0_TestCase_Modbus")]
         [TestCaseSource(typeof(CommentMethodsModbusTests), "LimitStatusStringComment_Case1_TestCase_Modbus")]
         [TestCaseSource(typeof(CommentMethodsModbusTests), "LimitStatusStringComment_Case2_TestCase_Modbus")]


### PR DESCRIPTION
JetBusConnection : Change ReadSingle(object command) method to directly read values from peer, according to parameter command.