### PR TITLE
WtxModbus : Add timer Stop() & Restart() calls ; JetbusTest : Delete warnings ; Fix StackOverFlowException 

### DIFF
--- a/Examples/GUIsimple/GUIsimpleForm.cs
+++ b/Examples/GUIsimple/GUIsimpleForm.cs
@@ -195,6 +195,7 @@ namespace GUIsimple
         private void DisplayText(string text)
         {
             txtInfo.Text = text;
+            Application.DoEvents();
         }
         
         //Connect device

--- a/HBM.Weighing.API/WTX/WTXModbus.cs
+++ b/HBM.Weighing.API/WTX/WTXModbus.cs
@@ -44,6 +44,7 @@ namespace Hbm.Weighing.API.WTX
     {
         #region ==================== constants & fields ====================        
         private int _manualTareValue;
+        private bool _result;
         #endregion
 
         #region ==================== events & delegates ====================
@@ -222,7 +223,9 @@ namespace Hbm.Weighing.API.WTX
         {
             Stop();                        
             Connection.Write(ModbusCommands.LDWZeroSignal, 0x7FFFFFFF);
-            return Connection.Write(ModbusCommands.ControlWordAdjustZero, 1);
+            _result = Connection.Write(ModbusCommands.ControlWordAdjustZero, 1);
+            Restart();
+            return _result;
         }
 
         /// <inheritdoc />
@@ -230,17 +233,20 @@ namespace Hbm.Weighing.API.WTX
         {
             this.Stop();
             Connection.Write(ModbusCommands.LWTNominalSignal, 0x7FFFFFFF);
-            return Connection.Write(ModbusCommands.ControlWordAdjustZero, 1);
+            _result = Connection.Write(ModbusCommands.ControlWordAdjustZero, 1);
+            this.Restart();
+            return _result;
         }
 
         /// <inheritdoc />
         public override bool AdjustNominalSignalWithCalibrationWeight(double adjustmentWeight)
         {
+            Stop();
             Connection.Write(ModbusCommands.CWTScaleCalibrationWeight, MeasurementUtils.DoubleToDigit(adjustmentWeight,ProcessData.Decimals));    
             Connection.Write(ModbusCommands.LWTNominalSignal, 0x7FFFFFFF);          
-            bool result = Connection.Write(ModbusCommands.ControlWordAdjustNominal, 1);
+            _result = Connection.Write(ModbusCommands.ControlWordAdjustNominal, 1);
             this.Restart();
-            return result;
+            return _result;
         }
 
         /// <inheritdoc />

--- a/HBM.Weighing.API/WTX/WTXModbus.cs
+++ b/HBM.Weighing.API/WTX/WTXModbus.cs
@@ -128,14 +128,11 @@ namespace Hbm.Weighing.API.WTX
         /// <inheritdoc />
         protected override void ProcessDataUpdateTick(object info)
         {
-            Stop();
             if (IsConnected)
             {
                 ((ModbusTCPConnection)Connection).SyncData();
                 ProcessDataReceived?.Invoke(this, new ProcessDataReceivedEventArgs(ProcessData));
             }
-
-            Restart();
         }
 
         /// <inheritdoc />

--- a/Tests/JetbusTest/SetTests.cs
+++ b/Tests/JetbusTest/SetTests.cs
@@ -19,9 +19,7 @@ namespace JetbusTest
     [TestFixture]
     public class SetTests
     {
-        private TestJetbusConnection _jetTestConnection;
-        private WTXJet _wtxObj;
-        
+
         // Test case source for writing values to the WTX120 device : Zeroing
         public static IEnumerable setTests
         {

--- a/Tests/JetbusTest/TestJetPeer.cs
+++ b/Tests/JetbusTest/TestJetPeer.cs
@@ -21,7 +21,7 @@ namespace JetbusTest
         private TestJetbusConnection _connection;
         private Behavior behavior;
 
-        private string path;
+        private string path = "";
         private string Event;
         private int data;
 


### PR DESCRIPTION
JetbusTest   : Delete warnings.
WtxModbus : Add timer Stop() & Restart() calls in adjusting zero and and calibration methods.
Fix StackOverFlowException (caused by recursive call of ProcessDataUpdateTick after DoEvents).